### PR TITLE
Add intl module

### DIFF
--- a/php7.4/apache/Dockerfile
+++ b/php7.4/apache/Dockerfile
@@ -42,6 +42,7 @@ RUN set -eux; \
 		bz2 \
 		exif \
 		gd \
+		intl \
 		opcache \
 		pcntl \
 		pdo_mysql \


### PR DESCRIPTION
I see intl being used across various projects we work on. Compiling it on CI takes a lot of time so adding it to the base image.