### PR TITLE
feat: add PHP 8.5 support for all build variants

### DIFF
--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: ["8.1", "8.2", "8.3", "8.4"]
+        php_version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
         variant: ["apache-trixie", "apache-bookworm", "fpm-alpine"]
     steps:
       - name: Checkout
@@ -40,7 +40,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
         if: github.event_name != 'pull_request'
       - name: Set Dockerfile directory
-        if: ${{ matrix.php_version == '8.1' || matrix.php_version == '8.2' || matrix.php_version == '8.3' || matrix.php_version == '8.4' }}
+        if: ${{ matrix.php_version == '8.1' || matrix.php_version == '8.2' || matrix.php_version == '8.3' || matrix.php_version == '8.4' || matrix.php_version == '8.5' }}
         run: echo "DOCKERFILE_DIR=php8" >> $GITHUB_ENV
       - name: Generate Docker tags
         id: tags
@@ -59,7 +59,7 @@ jobs:
           fi
 
           # For the latest PHP version on apache-trixie, add the latest tag
-          if [ "${{ matrix.php_version }}" = "8.4" ] && [ "${{ matrix.variant }}" = "apache-trixie" ]; then
+          if [ "${{ matrix.php_version }}" = "8.5" ] && [ "${{ matrix.variant }}" = "apache-trixie" ]; then
             TAGS="${TAGS},hussainweb/drupal-base:latest"
           fi
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,29 @@ This repository contains two main variants of the Drupal base image:
 
 Choose the image that best fits your needs. The Apache image is a good choice for a simple, all-in-one container, while the FPM image is ideal for use with a separate web server like Nginx.
 
+## Supported PHP Versions
+
+This image supports the following PHP versions:
+
+- PHP 8.1
+- PHP 8.2
+- PHP 8.3
+- PHP 8.4
+- PHP 8.5 (latest)
+
+Each version is available in all variants (apache-bookworm, apache-trixie, fpm-alpine).
+
+### Available Tags
+
+- `php8.5`, `latest` - PHP 8.5 with Apache on Debian Trixie
+- `php8.5-apache-trixie` - PHP 8.5 with Apache on Debian Trixie
+- `php8.5-apache-bookworm` - PHP 8.5 with Apache on Debian Bookworm
+- `php8.5-alpine`, `php8.5-fpm-alpine`, `latest-alpine` - PHP 8.5 FPM on Alpine Linux
+- `php8.4`, `php8.3`, `php8.2`, `php8.1` - Older PHP versions with Apache on Debian Trixie
+- `php8.4-alpine`, `php8.3-alpine`, `php8.2-alpine`, `php8.1-alpine` - Older PHP versions FPM on Alpine Linux
+
+All images support both `linux/amd64` and `linux/arm64` architectures.
+
 ## Usage
 
 ### Apache
@@ -22,7 +45,7 @@ Here is an example `docker-compose.yml` snippet:
 ```yaml
 services:
   drupal:
-    image: hussainweb/drupal-base:php8.4
+    image: hussainweb/drupal-base:php8.5
     volumes:
       - ./path/to/your/drupal/root:/var/www/html
     ports:
@@ -39,7 +62,7 @@ Here is an example `docker-compose.yml` snippet:
 ```yaml
 services:
   drupal:
-    image: hussainweb/drupal-base:php8.4-alpine
+    image: hussainweb/drupal-base:php8.5-alpine
     volumes:
       - ./path/to/your/drupal/root:/var/www/html
     restart: always

--- a/build.sh
+++ b/build.sh
@@ -10,10 +10,12 @@ docker pull php:8.1-apache-bookworm
 docker pull php:8.2-apache-bookworm
 docker pull php:8.3-apache-bookworm
 docker pull php:8.4-apache-bookworm
+docker pull php:8.5-apache-bookworm
 docker pull php:8.1-fpm-alpine
 docker pull php:8.2-fpm-alpine
 docker pull php:8.3-fpm-alpine
 docker pull php:8.4-fpm-alpine
+docker pull php:8.5-fpm-alpine
 docker pull composer:2
 
 docker buildx create --use --name drupal-base-builder
@@ -21,10 +23,12 @@ docker buildx create --use --name drupal-base-builder
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.1 --build-arg PHP_VERSION=8.1-apache-bookworm ${dir}/php8/apache-bookworm/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.2 --build-arg PHP_VERSION=8.2-apache-bookworm ${dir}/php8/apache-bookworm/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.3 --build-arg PHP_VERSION=8.3-apache-bookworm ${dir}/php8/apache-bookworm/
-docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.4 --tag hussainweb/drupal-base:latest --build-arg PHP_VERSION=8.4-apache-bookworm ${dir}/php8/fpm-alpine/
+docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.4 --build-arg PHP_VERSION=8.4-apache-bookworm ${dir}/php8/apache-bookworm/
+docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.5 --tag hussainweb/drupal-base:latest --build-arg PHP_VERSION=8.5-apache-bookworm ${dir}/php8/fpm-alpine/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.1-alpine --build-arg PHP_VERSION=8.1-fpm-alpine ${dir}/php8/fpm-alpine/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.2-alpine --build-arg PHP_VERSION=8.2-fpm-alpine ${dir}/php8/fpm-alpine/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.3-alpine --build-arg PHP_VERSION=8.3-fpm-alpine ${dir}/php8/fpm-alpine/
-docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.4-alpine --tag hussainweb/drupal-base:latest-alpine --build-arg PHP_VERSION=8.4-fpm-alpine ${dir}/php8/fpm-alpine/
+docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.4-alpine --build-arg PHP_VERSION=8.4-fpm-alpine ${dir}/php8/fpm-alpine/
+docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.5-alpine --tag hussainweb/drupal-base:latest-alpine --build-arg PHP_VERSION=8.5-fpm-alpine ${dir}/php8/fpm-alpine/
 
 docker buildx rm drupal-base-builder

--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/d
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.2 --build-arg PHP_VERSION=8.2-apache-bookworm ${dir}/php8/apache-bookworm/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.3 --build-arg PHP_VERSION=8.3-apache-bookworm ${dir}/php8/apache-bookworm/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.4 --build-arg PHP_VERSION=8.4-apache-bookworm ${dir}/php8/apache-bookworm/
-docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.5 --tag hussainweb/drupal-base:latest --build-arg PHP_VERSION=8.5-apache-bookworm ${dir}/php8/fpm-alpine/
+docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.5 --tag hussainweb/drupal-base:latest --build-arg PHP_VERSION=8.5-apache-bookworm ${dir}/php8/apache-bookworm/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.1-alpine --build-arg PHP_VERSION=8.1-fpm-alpine ${dir}/php8/fpm-alpine/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.2-alpine --build-arg PHP_VERSION=8.2-fpm-alpine ${dir}/php8/fpm-alpine/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.3-alpine --build-arg PHP_VERSION=8.3-fpm-alpine ${dir}/php8/fpm-alpine/

--- a/clean.sh
+++ b/clean.sh
@@ -4,18 +4,22 @@ docker rmi php:8.1-apache-bullseye
 docker rmi php:8.2-apache-bullseye
 docker rmi php:8.3-apache-bullseye
 docker rmi php:8.4-apache-bullseye
+docker rmi php:8.5-apache-bullseye
 docker rmi php:8.1-fpm-alpine
 docker rmi php:8.2-fpm-alpine
 docker rmi php:8.3-fpm-alpine
 docker rmi php:8.4-fpm-alpine
+docker rmi php:8.5-fpm-alpine
 docker rmi composer:2
 
 docker rmi hussainweb/drupal-base:php8.1
 docker rmi hussainweb/drupal-base:php8.2
 docker rmi hussainweb/drupal-base:php8.3
 docker rmi hussainweb/drupal-base:php8.4
+docker rmi hussainweb/drupal-base:php8.5
 docker rmi hussainweb/drupal-base:php8.1-alpine
 docker rmi hussainweb/drupal-base:php8.2-alpine
 docker rmi hussainweb/drupal-base:php8.3-alpine
 docker rmi hussainweb/drupal-base:php8.4-alpine
+docker rmi hussainweb/drupal-base:php8.5-alpine
 docker rmi hussainweb/drupal-base:latest

--- a/php8/apache-bookworm/Dockerfile
+++ b/php8/apache-bookworm/Dockerfile
@@ -42,13 +42,23 @@ RUN set -eux; \
 		--with-webp \
 	; \
 	\
+	# Extract PHP major.minor version from PHP_VERSION (e.g., "8.5" from "8.5-apache-bookworm")
+	PHP_MAJOR_MINOR=$(echo "${PHP_VERSION}" | cut -d'-' -f1); \
+	# Opcache is bundled in PHP 8.5+, so only install it for earlier versions
+	case "$PHP_MAJOR_MINOR" in \
+		8.[5-9]*|[9-9]*.*) \
+			OPCACHE_EXT="" ;; \
+		*) \
+			OPCACHE_EXT="opcache" ;; \
+	esac; \
+	\
 	docker-php-ext-install -j "$(nproc)" \
 		bcmath \
 		bz2 \
 		exif \
 		gd \
 		intl \
-		opcache \
+		$OPCACHE_EXT \
 		pcntl \
 		pdo_mysql \
 		pdo_pgsql \

--- a/php8/apache-trixie/Dockerfile
+++ b/php8/apache-trixie/Dockerfile
@@ -42,13 +42,23 @@ RUN set -eux; \
 		--with-webp \
 	; \
 	\
+	# Extract PHP major.minor version from PHP_VERSION (e.g., "8.5" from "8.5-apache-trixie")
+	PHP_MAJOR_MINOR=$(echo "${PHP_VERSION}" | cut -d'-' -f1); \
+	# Opcache is bundled in PHP 8.5+, so only install it for earlier versions
+	case "$PHP_MAJOR_MINOR" in \
+		8.[5-9]*|[9-9]*.*) \
+			OPCACHE_EXT="" ;; \
+		*) \
+			OPCACHE_EXT="opcache" ;; \
+	esac; \
+	\
 	docker-php-ext-install -j "$(nproc)" \
 		bcmath \
 		bz2 \
 		exif \
 		gd \
 		intl \
-		opcache \
+		$OPCACHE_EXT \
 		pcntl \
 		pdo_mysql \
 		pdo_pgsql \

--- a/php8/fpm-alpine/Dockerfile
+++ b/php8/fpm-alpine/Dockerfile
@@ -38,13 +38,23 @@ RUN set -eux; \
 		--with-webp \
 	; \
 	\
+	# Extract PHP major.minor version from PHP_VERSION (e.g., "8.5" from "8.5-fpm-alpine")
+	PHP_MAJOR_MINOR=$(echo "${PHP_VERSION}" | cut -d'-' -f1); \
+	# Opcache is bundled in PHP 8.5+, so only install it for earlier versions
+	case "$PHP_MAJOR_MINOR" in \
+		8.[5-9]*|[9-9]*.*) \
+			OPCACHE_EXT="" ;; \
+		*) \
+			OPCACHE_EXT="opcache" ;; \
+	esac; \
+	\
 	docker-php-ext-install -j "$(nproc)" \
 	    bcmath \
 		bz2 \
 		exif \
         gd \
 		intl \
-        opcache \
+        $OPCACHE_EXT \
         pcntl \
         pdo_mysql \
 		pdo_pgsql \


### PR DESCRIPTION
This PR adds PHP 8.5 support to all Docker image variants.

## Changes
- Add PHP 8.5 to GitHub Actions workflow matrix
- Update build.sh to include PHP 8.5 docker pulls and builds
- Update clean.sh to remove PHP 8.5 images
- Update README.md with PHP 8.5 as the latest version
- Add comprehensive documentation of supported PHP versions and available tags
- Move \`latest\` and \`latest-alpine\` tags from PHP 8.4 to PHP 8.5

All variants (apache-trixie, apache-bookworm, fpm-alpine) now support PHP 8.5.

## Testing
The GitHub Actions workflow will build and push images for all PHP versions including 8.5 upon merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for PHP 8.5 across all variants; PHP 8.5 is now the latest tag.

* **Bug Fixes**
  * Opcache is no longer installed by default on PHP 8.5+ builds while retained for older PHP versions.

* **Documentation**
  * Updated supported PHP versions, available tags, usage examples, and docker-compose snippets to reflect PHP 8.5.

* **Chores**
  * Build and cleanup scripts updated to include PHP 8.5 artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->