### PR TITLE
chore: Remove PHP 8.1 support

### DIFF
--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
+        php_version: ["8.2", "8.3", "8.4", "8.5"]
         variant: ["apache-trixie", "apache-bookworm", "fpm-alpine"]
     steps:
       - name: Checkout
@@ -40,7 +40,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
         if: github.event_name != 'pull_request'
       - name: Set Dockerfile directory
-        if: ${{ matrix.php_version == '8.1' || matrix.php_version == '8.2' || matrix.php_version == '8.3' || matrix.php_version == '8.4' || matrix.php_version == '8.5' }}
+        if: ${{ matrix.php_version == '8.2' || matrix.php_version == '8.3' || matrix.php_version == '8.4' || matrix.php_version == '8.5' }}
         run: echo "DOCKERFILE_DIR=php8" >> $GITHUB_ENV
       - name: Generate Docker tags
         id: tags

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Choose the image that best fits your needs. The Apache image is a good choice fo
 
 This image supports the following PHP versions:
 
-- PHP 8.1
 - PHP 8.2
 - PHP 8.3
 - PHP 8.4
@@ -29,8 +28,8 @@ Each version is available in all variants (apache-bookworm, apache-trixie, fpm-a
 - `php8.5-apache-trixie` - PHP 8.5 with Apache on Debian Trixie
 - `php8.5-apache-bookworm` - PHP 8.5 with Apache on Debian Bookworm
 - `php8.5-alpine`, `php8.5-fpm-alpine`, `latest-alpine` - PHP 8.5 FPM on Alpine Linux
-- `php8.4`, `php8.3`, `php8.2`, `php8.1` - Older PHP versions with Apache on Debian Trixie
-- `php8.4-alpine`, `php8.3-alpine`, `php8.2-alpine`, `php8.1-alpine` - Older PHP versions FPM on Alpine Linux
+- `php8.4`, `php8.3`, `php8.2` - Older PHP versions with Apache on Debian Trixie
+- `php8.4-alpine`, `php8.3-alpine`, `php8.2-alpine` - Older PHP versions FPM on Alpine Linux
 
 All images support both `linux/amd64` and `linux/arm64` architectures.
 

--- a/build.sh
+++ b/build.sh
@@ -6,12 +6,10 @@ set -ex
 
 export DOCKER_BUILDKIT=1
 
-docker pull php:8.1-apache-bookworm
 docker pull php:8.2-apache-bookworm
 docker pull php:8.3-apache-bookworm
 docker pull php:8.4-apache-bookworm
 docker pull php:8.5-apache-bookworm
-docker pull php:8.1-fpm-alpine
 docker pull php:8.2-fpm-alpine
 docker pull php:8.3-fpm-alpine
 docker pull php:8.4-fpm-alpine
@@ -20,12 +18,10 @@ docker pull composer:2
 
 docker buildx create --use --name drupal-base-builder
 
-docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.1 --build-arg PHP_VERSION=8.1-apache-bookworm ${dir}/php8/apache-bookworm/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.2 --build-arg PHP_VERSION=8.2-apache-bookworm ${dir}/php8/apache-bookworm/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.3 --build-arg PHP_VERSION=8.3-apache-bookworm ${dir}/php8/apache-bookworm/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.4 --build-arg PHP_VERSION=8.4-apache-bookworm ${dir}/php8/apache-bookworm/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.5 --tag hussainweb/drupal-base:latest --build-arg PHP_VERSION=8.5-apache-bookworm ${dir}/php8/apache-bookworm/
-docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.1-alpine --build-arg PHP_VERSION=8.1-fpm-alpine ${dir}/php8/fpm-alpine/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.2-alpine --build-arg PHP_VERSION=8.2-fpm-alpine ${dir}/php8/fpm-alpine/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.3-alpine --build-arg PHP_VERSION=8.3-fpm-alpine ${dir}/php8/fpm-alpine/
 docker buildx build --push --platform linux/amd64,linux/arm64 --tag hussainweb/drupal-base:php8.4-alpine --build-arg PHP_VERSION=8.4-fpm-alpine ${dir}/php8/fpm-alpine/

--- a/clean.sh
+++ b/clean.sh
@@ -1,23 +1,19 @@
 #!/usr/bin/env bash
 
-docker rmi php:8.1-apache-bullseye
 docker rmi php:8.2-apache-bullseye
 docker rmi php:8.3-apache-bullseye
 docker rmi php:8.4-apache-bullseye
 docker rmi php:8.5-apache-bullseye
-docker rmi php:8.1-fpm-alpine
 docker rmi php:8.2-fpm-alpine
 docker rmi php:8.3-fpm-alpine
 docker rmi php:8.4-fpm-alpine
 docker rmi php:8.5-fpm-alpine
 docker rmi composer:2
 
-docker rmi hussainweb/drupal-base:php8.1
 docker rmi hussainweb/drupal-base:php8.2
 docker rmi hussainweb/drupal-base:php8.3
 docker rmi hussainweb/drupal-base:php8.4
 docker rmi hussainweb/drupal-base:php8.5
-docker rmi hussainweb/drupal-base:php8.1-alpine
 docker rmi hussainweb/drupal-base:php8.2-alpine
 docker rmi hussainweb/drupal-base:php8.3-alpine
 docker rmi hussainweb/drupal-base:php8.4-alpine


### PR DESCRIPTION
PHP 8.1 is no longer supported as of this commit. This change removes its usage from the GitHub Actions workflow, README, and build/clean scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Discontinued PHP 8.1 support. Removed from Docker build configurations, test matrix, generated tags, and documentation.
  * Updated build and cleanup scripts to remove PHP 8.1 variant handling.
  * Supported versions now focus on PHP 8.2 through 8.5.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->