### PR TITLE
feat: Add workflow to test Drupal installations

### DIFF
--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -3,10 +3,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "5 4 1,15 * *"
-  push:
+  workflow_run:
+    workflows: ["Test Drupal Installation"]
     branches: [main]
-  pull_request:
-    branches: [main]
+    types:
+      - completed
 
 env:
   DOCKERFILE_DIR: php8
@@ -17,11 +18,18 @@ concurrency:
 
 jobs:
   buildx:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     strategy:
       matrix:
         php_version: ["8.2", "8.3", "8.4", "8.5"]
-        variant: ["apache-trixie", "apache-bookworm", "fpm-alpine", "frankenphp-trixie"]
+        variant:
+          [
+            "apache-trixie",
+            "apache-bookworm",
+            "fpm-alpine",
+            "frankenphp-trixie",
+          ]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -50,7 +50,9 @@ jobs:
         with:
           username: hussainweb
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: github.event_name != 'pull_request'
+        if: |
+          (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main') ||
+          (github.event_name != 'workflow_run' && github.ref == 'refs/heads/main')
       - name: Set Dockerfile directory
         if: ${{ matrix.php_version == '8.2' || matrix.php_version == '8.3' || matrix.php_version == '8.4' || matrix.php_version == '8.5' }}
         run: echo "DOCKERFILE_DIR=php8" >> $GITHUB_ENV
@@ -80,7 +82,9 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ${{ env.DOCKERFILE_DIR }}/${{ matrix.variant }}/
-          push: ${{ github.event_name != 'pull_request' }}
+          push: |
+            ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main') ||
+                (github.event_name != 'workflow_run' && github.ref == 'refs/heads/main') }}
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |
             PHP_VERSION=${{ matrix.php_version }}

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -63,6 +63,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install docker-compose
+        run: |
+          set -x
+          sudo apt-get update
+          sudo apt-get install -y docker-compose-plugin
+
       - name: Create docker-compose for testing
         run: |
           cat <<EOF > docker-compose.test.yml
@@ -110,7 +116,7 @@ jobs:
           EOF
 
       - name: Start services
-        run: docker-compose -f docker-compose.test.yml up -d --build
+        run: docker compose -f docker-compose.test.yml up -d --build
 
       - name: Test Drupal Installation
         run: |
@@ -125,4 +131,4 @@ jobs:
 
       - name: Stop services
         if: always()
-        run: docker-compose -f docker-compose.test.yml down --volumes
+        run: docker compose -f docker-compose.test.yml down --volumes

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -64,6 +64,7 @@ jobs:
 
       - name: Install Drupal site
         run: |
+          docker exec --workdir ${{ env.WEB_ROOT }} ${{ env.CONTAINER_NAME }} sh -c "mkdir -p web/sites/default/files && chmod -R 777 web/sites/default/files"
           docker exec --workdir ${{ env.WEB_ROOT }}/web ${{ env.CONTAINER_NAME }} sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
 
           if [ "${{ matrix.variant }}" = "apache-trixie" ]; then
@@ -169,7 +170,7 @@ jobs:
 
       - name: Install Drupal site
         run: |
-          docker exec --workdir /var/www/html php-fpm sh -c "mkdir -p web/sites/default/files && chown -R www-data:www-data web/sites/default"
+          docker exec --workdir /var/www/html php-fpm sh -c "mkdir -p web/sites/default/files && chmod -R 777 web/sites/default/files"
           docker exec --workdir /var/www/html/web php-fpm sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
           sleep 10
 

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install Drupal site
         run: |
-          docker exec --workdir ${{ env.WEB_ROOT }} ${{ env.CONTAINER_NAME }} sh -c "mkdir -p web/sites/default/files && chmod -R 777 web/sites/default/files"
+          docker exec --workdir ${{ env.WEB_ROOT }} ${{ env.CONTAINER_NAME }} sh -c "mkdir -p web/sites/default/files && chmod -R 777 web/sites/default"
           docker exec --workdir ${{ env.WEB_ROOT }}/web ${{ env.CONTAINER_NAME }} sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
 
           sleep 10
@@ -166,7 +166,7 @@ jobs:
 
       - name: Install Drupal site
         run: |
-          docker exec --workdir /var/www/html php-fpm sh -c "mkdir -p web/sites/default/files && chmod -R 777 web/sites/default/files"
+          docker exec --workdir /var/www/html php-fpm sh -c "mkdir -p web/sites/default/files && chmod -R 777 web/sites/default"
           docker exec --workdir /var/www/html/web php-fpm sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
           sleep 10
 

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -24,34 +24,60 @@ jobs:
             -t drupal-test:${{ matrix.php_version }}-${{ matrix.variant }} \
             ./php8/${{ matrix.variant }}
 
-      - name: Test Drupal Installation
+      - name: Run test container
         run: |
           WEB_ROOT=/var/www/html
           if [ "${{ matrix.variant }}" = "frankenphp-trixie" ]; then
             WEB_ROOT=/app
           fi
+          echo "WEB_ROOT=${WEB_ROOT}" >> $GITHUB_ENV
 
           PORT=8080
+          echo "PORT=${PORT}" >> $GITHUB_ENV
+
           CONTAINER_NAME=test-container
+          echo "CONTAINER_NAME=${CONTAINER_NAME}" >> $GITHUB_ENV
 
           docker run -d -p $PORT:80 --name $CONTAINER_NAME drupal-test:${{ matrix.php_version }}-${{ matrix.variant }}
+
+      - name: Install dependencies
+        run: |
+          sleep 10
+          docker exec ${{ env.CONTAINER_NAME }} sh -c "apt-get update && apt-get install -y --no-install-recommends git curl unzip rsync"
+
+      - name: Install Drupal
+        run: |
+          docker exec --workdir ${{ env.WEB_ROOT }} ${{ env.CONTAINER_NAME }} sh -c "composer create-project drupal/recommended-project drupal_project --no-interaction && rsync -a drupal_project/ . && rm -rf drupal_project"
+          docker exec --workdir ${{ env.WEB_ROOT }} ${{ env.CONTAINER_NAME }} sh -c "composer require drush/drush"
+
+      - name: Configure Apache
+        if: matrix.variant == 'apache-trixie'
+        run: |
+          docker exec ${{ env.CONTAINER_NAME }} a2enmod rewrite
+          docker exec ${{ env.CONTAINER_NAME }} apache2ctl -k graceful
+
+      - name: Install Drupal site
+        run: |
+          docker exec --workdir ${{ env.WEB_ROOT }}/web ${{ env.CONTAINER_NAME }} sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
           sleep 10
 
-          docker exec $CONTAINER_NAME sh -c "apt-get update && apt-get install -y --no-install-recommends git curl unzip rsync"
+      - name: Verify Drupal installation
+        run: curl -v --fail http://localhost:${{ env.PORT }}
 
-          docker exec --workdir $WEB_ROOT $CONTAINER_NAME sh -c "composer create-project drupal/recommended-project drupal_project --no-interaction && rsync -av drupal_project/ . && rm -rf drupal_project"
-          docker exec --workdir $WEB_ROOT $CONTAINER_NAME sh -c "composer require drush/drush"
-
+      - name: Show logs on failure
+        if: failure()
+        run: |
+          echo "::group::File permissions on sites/default"
+          docker exec ${{ env.CONTAINER_NAME }} ls -la ${{ env.WEB_ROOT }}/web/sites/default
+          echo "::endgroup::"
+          echo "::group::Docker logs"
+          docker logs ${{ env.CONTAINER_NAME }}
+          echo "::endgroup::"
           if [ "${{ matrix.variant }}" = "apache-trixie" ]; then
-            docker exec $CONTAINER_NAME a2enmod rewrite
-            docker exec $CONTAINER_NAME apache2ctl -k graceful
+            echo "::group::Apache error log"
+            docker exec ${{ env.CONTAINER_NAME }} cat /var/log/apache2/error.log
+            echo "::endgroup::"
           fi
-
-          docker exec --workdir $WEB_ROOT/web $CONTAINER_NAME sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
-
-          sleep 10
-          # Use curl to check for a successful installation
-          curl -v --fail http://localhost:$PORT
 
   test-fpm:
     runs-on: ubuntu-latest
@@ -115,16 +141,33 @@ jobs:
       - name: Start services
         run: docker compose -f docker-compose.test.yml up -d --build
 
-      - name: Test Drupal Installation
+      - name: Install Drupal
         run: |
           sleep 10
           docker exec php-fpm sh -c "apk add --no-cache git curl unzip"
           docker exec --workdir /var/www/html php-fpm sh -c "composer create-project drupal/recommended-project . --no-interaction"
           docker exec --workdir /var/www/html php-fpm sh -c "composer require drush/drush"
           docker exec --workdir /var/www/html/web php-fpm sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
-
           sleep 10
-          curl -v --fail http://localhost:8080
+
+      - name: Verify Drupal installation
+        run: curl -v --fail http://localhost:8080
+
+      - name: Show logs on failure
+        if: failure()
+        run: |
+          echo "::group::File permissions on sites/default"
+          docker exec php-fpm ls -la /var/www/html/web/sites/default
+          echo "::endgroup::"
+          echo "::group::Nginx container logs"
+          docker logs nginx
+          echo "::endgroup::"
+          echo "::group::Nginx error log"
+          docker exec nginx cat /var/log/nginx/error.log
+          echo "::endgroup::"
+          echo "::group::PHP-FPM container logs"
+          docker logs php-fpm
+          echo "::endgroup::"
 
       - name: Stop services
         if: always()

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -67,12 +67,9 @@ jobs:
           docker exec --workdir ${{ env.WEB_ROOT }}/web ${{ env.CONTAINER_NAME }} sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
 
           if [ "${{ matrix.variant }}" = "apache-trixie" ]; then
-            user="www-data"
-          else
-            user="frankenphp"
+            docker exec ${{ env.CONTAINER_NAME }} chown -R www-data:www-data ${{ env.WEB_ROOT }}
           fi
 
-          docker exec ${{ env.CONTAINER_NAME }} chown -R $user:$user ${{ env.WEB_ROOT }}/web/sites
           sleep 10
 
       - name: Verify Drupal installation

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -37,9 +37,9 @@ jobs:
           docker run -d -p $PORT:80 --name $CONTAINER_NAME drupal-test:${{ matrix.php_version }}-${{ matrix.variant }}
           sleep 10
 
-          docker exec $CONTAINER_NAME sh -c "apt-get update && apt-get install -y --no-install-recommends git curl unzip"
+          docker exec $CONTAINER_NAME sh -c "apt-get update && apt-get install -y --no-install-recommends git curl unzip rsync"
 
-          docker exec --workdir $WEB_ROOT $CONTAINER_NAME sh -c "composer create-project drupal/recommended-project . --no-interaction"
+          docker exec --workdir $WEB_ROOT $CONTAINER_NAME sh -c "composer create-project drupal/recommended-project drupal_project --no-interaction && rsync -av drupal_project/ . && rm -rf drupal_project"
           docker exec --workdir $WEB_ROOT $CONTAINER_NAME sh -c "composer require drush/drush"
 
           if [ "${{ matrix.variant }}" = "apache-trixie" ]; then

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -158,6 +158,7 @@ jobs:
           docker exec php-fpm sh -c "apk add --no-cache git curl unzip"
           docker exec --workdir /var/www/html php-fpm sh -c "composer create-project drupal/recommended-project . --no-interaction"
           docker exec --workdir /var/www/html php-fpm sh -c "composer require drush/drush"
+          docker exec php-fpm chown -R www-data:www-data /var/www/html
 
       - name: Enable PHP error display for debugging
         run: |
@@ -165,6 +166,7 @@ jobs:
           docker exec php-fpm sh -c "sed -i 's/display_errors = Off/display_errors = On/g' $PHP_INI_PATH"
           docker exec php-fpm sh -c "sed -i 's/error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT/error_reporting = E_ALL/g' $PHP_INI_PATH"
           docker exec php-fpm kill -USR2 1
+          sleep 5
 
       - name: Install Drupal site
         run: |

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -44,14 +44,14 @@ jobs:
 
           if [ "${{ matrix.variant }}" = "apache-trixie" ]; then
             docker exec $CONTAINER_NAME a2enmod rewrite
-            docker exec $CONTAINER_NAME service apache2 restart
+            docker exec $CONTAINER_NAME apache2ctl -k graceful
           fi
 
           docker exec --workdir $WEB_ROOT/web $CONTAINER_NAME sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
 
           sleep 10
           # Use curl to check for a successful installation
-          curl -sI http://localhost:$PORT | grep "HTTP/1.1 200 OK"
+          curl -v --fail http://localhost:$PORT
 
   test-fpm:
     runs-on: ubuntu-latest
@@ -124,7 +124,7 @@ jobs:
           docker exec --workdir /var/www/html/web php-fpm sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
 
           sleep 10
-          curl -sI http://localhost:8080 | grep "HTTP/1.1 200 OK"
+          curl -v --fail http://localhost:8080
 
       - name: Stop services
         if: always()

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -1,0 +1,128 @@
+name: Test Drupal Installation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test-apache-frankenphp:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php_version: ["8.4", "8.5"]
+        variant: ["apache-trixie", "frankenphp-trixie"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            --build-arg PHP_VERSION=${{ matrix.php_version }} \
+            -t drupal-test:${{ matrix.php_version }}-${{ matrix.variant }} \
+            ./php8/${{ matrix.variant }}
+
+      - name: Test Drupal Installation
+        run: |
+          WEB_ROOT=/var/www/html
+          if [ "${{ matrix.variant }}" = "frankenphp-trixie" ]; then
+            WEB_ROOT=/app
+          fi
+
+          PORT=8080
+          CONTAINER_NAME=test-container
+
+          docker run -d -p $PORT:80 --name $CONTAINER_NAME drupal-test:${{ matrix.php_version }}-${{ matrix.variant }}
+          sleep 10
+
+          docker exec $CONTAINER_NAME sh -c "apt-get update && apt-get install -y --no-install-recommends git curl unzip"
+
+          docker exec --workdir $WEB_ROOT $CONTAINER_NAME sh -c "composer create-project drupal/recommended-project . --no-interaction"
+          docker exec --workdir $WEB_ROOT $CONTAINER_NAME sh -c "composer require drush/drush"
+
+          if [ "${{ matrix.variant }}" = "apache-trixie" ]; then
+            docker exec $CONTAINER_NAME a2enmod rewrite
+            docker exec $CONTAINER_NAME service apache2 restart
+          fi
+
+          docker exec --workdir $WEB_ROOT/web $CONTAINER_NAME sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
+
+          sleep 10
+          # Use curl to check for a successful installation
+          curl -sI http://localhost:$PORT | grep "HTTP/1.1 200 OK"
+
+  test-fpm:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php_version: ["8.4", "8.5"]
+        variant: ["fpm-alpine"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create docker-compose for testing
+        run: |
+          cat <<EOF > docker-compose.test.yml
+          services:
+            php-fpm:
+              build:
+                context: ./php8/fpm-alpine
+                args:
+                  PHP_VERSION: ${{ matrix.php_version }}
+              container_name: php-fpm
+              volumes:
+                - drupal-code:/var/www/html
+            nginx:
+              image: nginx:alpine
+              container_name: nginx
+              ports:
+                - "8080:80"
+              volumes:
+                - drupal-code:/var/www/html
+                - ./nginx.conf:/etc/nginx/conf.d/default.conf
+          volumes:
+            drupal-code:
+          EOF
+
+      - name: Create nginx config
+        run: |
+          cat <<EOF > nginx.conf
+          server {
+              listen 80;
+              server_name localhost;
+              root /var/www/html/web;
+              index index.php;
+
+              location / {
+                  try_files \$uri /index.php?\$query_string;
+              }
+
+              location ~ \.php$ {
+                  fastcgi_pass php-fpm:9000;
+                  fastcgi_index index.php;
+                  include fastcgi_params;
+                  fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+              }
+          }
+          EOF
+
+      - name: Start services
+        run: docker-compose -f docker-compose.test.yml up -d --build
+
+      - name: Test Drupal Installation
+        run: |
+          sleep 10
+          docker exec php-fpm sh -c "apk add --no-cache git curl unzip"
+          docker exec --workdir /var/www/html php-fpm sh -c "composer create-project drupal/recommended-project . --no-interaction"
+          docker exec --workdir /var/www/html php-fpm sh -c "composer require drush/drush"
+          docker exec --workdir /var/www/html/web php-fpm sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
+
+          sleep 10
+          curl -sI http://localhost:8080 | grep "HTTP/1.1 200 OK"
+
+      - name: Stop services
+        if: always()
+        run: docker-compose -f docker-compose.test.yml down --volumes

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -50,6 +50,12 @@ jobs:
           docker exec --workdir ${{ env.WEB_ROOT }} ${{ env.CONTAINER_NAME }} sh -c "composer create-project drupal/recommended-project drupal_project --no-interaction && rsync -a drupal_project/ . && rm -rf drupal_project"
           docker exec --workdir ${{ env.WEB_ROOT }} ${{ env.CONTAINER_NAME }} sh -c "composer require drush/drush"
 
+      - name: Enable PHP error display for debugging
+        run: |
+          PHP_INI_PATH=$(docker exec ${{ env.CONTAINER_NAME }} php -i | grep "Loaded Configuration File" | cut -d' ' -f5)
+          docker exec ${{ env.CONTAINER_NAME }} sh -c "sed -i 's/display_errors = Off/display_errors = On/g' $PHP_INI_PATH"
+          docker exec ${{ env.CONTAINER_NAME }} sh -c "sed -i 's/error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT/error_reporting = E_ALL/g' $PHP_INI_PATH"
+
       - name: Configure Apache
         if: matrix.variant == 'apache-trixie'
         run: |
@@ -59,6 +65,14 @@ jobs:
       - name: Install Drupal site
         run: |
           docker exec --workdir ${{ env.WEB_ROOT }}/web ${{ env.CONTAINER_NAME }} sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
+
+          if [ "${{ matrix.variant }}" = "apache-trixie" ]; then
+            user="www-data"
+          else
+            user="frankenphp"
+          fi
+
+          docker exec ${{ env.CONTAINER_NAME }} chown -R $user:$user ${{ env.WEB_ROOT }}/web/sites
           sleep 10
 
       - name: Verify Drupal installation
@@ -147,7 +161,18 @@ jobs:
           docker exec php-fpm sh -c "apk add --no-cache git curl unzip"
           docker exec --workdir /var/www/html php-fpm sh -c "composer create-project drupal/recommended-project . --no-interaction"
           docker exec --workdir /var/www/html php-fpm sh -c "composer require drush/drush"
+
+      - name: Enable PHP error display for debugging
+        run: |
+          PHP_INI_PATH=$(docker exec php-fpm php -i | grep "Loaded Configuration File" | cut -d' ' -f5)
+          docker exec php-fpm sh -c "sed -i 's/display_errors = Off/display_errors = On/g' $PHP_INI_PATH"
+          docker exec php-fpm sh -c "sed -i 's/error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT/error_reporting = E_ALL/g' $PHP_INI_PATH"
+          docker exec php-fpm kill -USR2 1
+
+      - name: Install Drupal site
+        run: |
           docker exec --workdir /var/www/html/web php-fpm sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
+          docker exec php-fpm chown -R www-data:www-data /var/www/html/web/sites
           sleep 10
 
       - name: Verify Drupal installation

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -39,57 +39,22 @@ jobs:
 
       - name: Set up environment variables
         run: |
+          echo "PHP_VERSION=${{ matrix.php_version }}" >> $GITHUB_ENV
+          echo "VARIANT=${{ matrix.variant }}" >> $GITHUB_ENV
           if [ "${{ matrix.variant }}" = "frankenphp-trixie" ]; then
             echo "WEB_ROOT=/app" >> $GITHUB_ENV
           else
             echo "WEB_ROOT=/var/www/html" >> $GITHUB_ENV
           fi
+          if [ "${{ matrix.variant }}" = "fpm-alpine" ]; then
+            echo "COMPOSE_FILE=tests/docker-compose.fpm.yml" >> $GITHUB_ENV
+          else
+            echo "COMPOSE_FILE=tests/docker-compose.yml" >> $GITHUB_ENV
+          fi
           echo "CONTAINER_NAME=drupal" >> $GITHUB_ENV
 
       - name: Start Docker containers
         run: |
-          if [ "${{ matrix.variant }}" = "fpm-alpine" ]; then
-            cat <<EOF > docker-compose.yml
-            services:
-              drupal:
-                image: drupal-test:${{ matrix.php_version }}-${{ matrix.variant }}
-                container_name: drupal
-                volumes:
-                  - ./drupal-root:/var/www/html
-              nginx:
-                image: nginx:alpine
-                container_name: nginx
-                ports:
-                  - "8080:80"
-                volumes:
-                  - ./drupal-root:/var/www/html
-                  - ./tests/nginx.conf:/etc/nginx/conf.d/default.conf:ro
-                depends_on:
-                  - drupal
-          EOF
-          elif [ "${{ matrix.variant }}" = "frankenphp-trixie" ]; then
-            cat <<EOF > docker-compose.yml
-            services:
-              drupal:
-                image: drupal-test:${{ matrix.php_version }}-${{ matrix.variant }}
-                container_name: drupal
-                volumes:
-                  - ./drupal-root:/app
-                ports:
-                  - "8080:80"
-          EOF
-          else
-            cat <<EOF > docker-compose.yml
-            services:
-              drupal:
-                image: drupal-test:${{ matrix.php_version }}-${{ matrix.variant }}
-                container_name: drupal
-                volumes:
-                  - ./drupal-root:/var/www/html
-                ports:
-                  - "8080:80"
-          EOF
-          fi
           docker compose up -d
           sleep 10
           docker compose ps
@@ -105,8 +70,8 @@ jobs:
           chmod +x tests/verify-drupal.sh
           ./tests/verify-drupal.sh ${{ matrix.variant }}
 
-      - name: Capture logs on failure
-        if: failure()
+      - name: Capture logs
+        if: always()
         run: |
           echo "=== Docker Compose Logs ==="
           docker compose logs
@@ -120,6 +85,7 @@ jobs:
         with:
           name: test-results-${{ matrix.php_version }}-${{ matrix.variant }}
           path: test-results/
+          if-no-files-found: ignore
 
       - name: Clean up
         if: always()

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -63,11 +63,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install docker-compose
-        run: |
-          set -x
-          sudo apt-get update
-          sudo apt-get install -y docker-compose-plugin
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
 
       - name: Create docker-compose for testing
         run: |

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -86,7 +86,7 @@ jobs:
           echo "::endgroup::"
           if [ "${{ matrix.variant }}" = "apache-trixie" ]; then
             echo "::group::Apache error log"
-            docker exec ${{ env.CONTAINER_NAME }} cat /var/log/apache2/error.log
+            docker exec ${{ env.CONTAINER_NAME }} tail -n 100 /var/log/apache2/error.log
             echo "::endgroup::"
           fi
 
@@ -187,7 +187,7 @@ jobs:
           docker logs nginx
           echo "::endgroup::"
           echo "::group::Nginx error log"
-          docker exec nginx cat /var/log/nginx/error.log
+          docker exec nginx tail -n 100 /var/log/nginx/error.log
           echo "::endgroup::"
           echo "::group::PHP-FPM container logs"
           docker logs php-fpm

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -86,7 +86,7 @@ jobs:
           echo "::endgroup::"
           if [ "${{ matrix.variant }}" = "apache-trixie" ]; then
             echo "::group::Apache error log"
-            docker exec ${{ env.CONTAINER_NAME }} tail -n 100 /var/log/apache2/error.log
+            timeout 10s docker exec ${{ env.CONTAINER_NAME }} tail -n 100 /var/log/apache2/error.log
             echo "::endgroup::"
           fi
 
@@ -183,14 +183,14 @@ jobs:
           echo "::group::File permissions on sites/default"
           docker exec php-fpm ls -la /var/www/html/web/sites/default
           echo "::endgroup::"
+          echo "::group::PHP-FPM container logs"
+          docker logs php-fpm
+          echo "::endgroup::"
           echo "::group::Nginx container logs"
           docker logs nginx
           echo "::endgroup::"
           echo "::group::Nginx error log"
-          docker exec nginx tail -n 100 /var/log/nginx/error.log
-          echo "::endgroup::"
-          echo "::group::PHP-FPM container logs"
-          docker logs php-fpm
+          timeout 10s docker exec nginx tail -n 100 /var/log/nginx/error.log
           echo "::endgroup::"
 
       - name: Stop services

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -67,10 +67,6 @@ jobs:
           docker exec --workdir ${{ env.WEB_ROOT }} ${{ env.CONTAINER_NAME }} sh -c "mkdir -p web/sites/default/files && chmod -R 777 web/sites/default/files"
           docker exec --workdir ${{ env.WEB_ROOT }}/web ${{ env.CONTAINER_NAME }} sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
 
-          if [ "${{ matrix.variant }}" = "apache-trixie" ]; then
-            docker exec ${{ env.CONTAINER_NAME }} chown -R www-data:www-data ${{ env.WEB_ROOT }}
-          fi
-
           sleep 10
 
       - name: Verify Drupal installation

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install Drupal site
         run: |
-          docker exec --workdir ${{ env.WEB_ROOT }} ${{ env.CONTAINER_NAME }} sh -c "mkdir -p web/sites/default/files && chmod -R 777 web/sites/default"
+          docker exec ${{ env.CONTAINER_NAME }} chmod -R 777 ${{ env.WEB_ROOT }}
           docker exec --workdir ${{ env.WEB_ROOT }}/web ${{ env.CONTAINER_NAME }} sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
 
           sleep 10
@@ -166,7 +166,7 @@ jobs:
 
       - name: Install Drupal site
         run: |
-          docker exec --workdir /var/www/html php-fpm sh -c "mkdir -p web/sites/default/files && chmod -R 777 web/sites/default"
+          docker exec php-fpm chmod -R 777 /var/www/html
           docker exec --workdir /var/www/html/web php-fpm sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
           sleep 10
 

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -158,7 +158,6 @@ jobs:
           docker exec php-fpm sh -c "apk add --no-cache git curl unzip"
           docker exec --workdir /var/www/html php-fpm sh -c "composer create-project drupal/recommended-project . --no-interaction"
           docker exec --workdir /var/www/html php-fpm sh -c "composer require drush/drush"
-          docker exec php-fpm chown -R www-data:www-data /var/www/html
 
       - name: Enable PHP error display for debugging
         run: |
@@ -170,8 +169,8 @@ jobs:
 
       - name: Install Drupal site
         run: |
+          docker exec --workdir /var/www/html php-fpm sh -c "mkdir -p web/sites/default/files && chown -R www-data:www-data web/sites/default"
           docker exec --workdir /var/www/html/web php-fpm sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
-          docker exec php-fpm chown -R www-data:www-data /var/www/html/web/sites
           sleep 10
 
       - name: Verify Drupal installation

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -7,13 +7,15 @@ on:
       - main
 
 jobs:
-  test-apache-frankenphp:
+  test-drupal:
+    name: Test on ${{ matrix.variant }} (PHP ${{ matrix.php_version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         php_version: ["8.4", "8.5"]
-        variant: ["apache-trixie", "frankenphp-trixie"]
+        variant: ["apache-trixie", "fpm-alpine", "frankenphp-trixie"]
+    
     steps:
       - uses: actions/checkout@v4
 
@@ -24,181 +26,101 @@ jobs:
             -t drupal-test:${{ matrix.php_version }}-${{ matrix.variant }} \
             ./php8/${{ matrix.variant }}
 
-      - name: Run test container
+      - name: Create test directory structure
         run: |
-          WEB_ROOT=/var/www/html
+          mkdir -p drupal-root
+          mkdir -p test-results
+
+      - name: Download Drupal
+        run: |
+          composer create-project drupal/recommended-project drupal-root --no-interaction --no-dev
+          cd drupal-root
+          composer require drush/drush --no-interaction
+
+      - name: Set up environment variables
+        run: |
           if [ "${{ matrix.variant }}" = "frankenphp-trixie" ]; then
-            WEB_ROOT=/app
+            echo "WEB_ROOT=/app" >> $GITHUB_ENV
+          else
+            echo "WEB_ROOT=/var/www/html" >> $GITHUB_ENV
           fi
-          echo "WEB_ROOT=${WEB_ROOT}" >> $GITHUB_ENV
+          echo "CONTAINER_NAME=drupal" >> $GITHUB_ENV
 
-          PORT=8080
-          echo "PORT=${PORT}" >> $GITHUB_ENV
-
-          CONTAINER_NAME=test-container
-          echo "CONTAINER_NAME=${CONTAINER_NAME}" >> $GITHUB_ENV
-
-          docker run -d -p $PORT:80 --name $CONTAINER_NAME drupal-test:${{ matrix.php_version }}-${{ matrix.variant }}
-
-      - name: Install dependencies
+      - name: Start Docker containers
         run: |
+          if [ "${{ matrix.variant }}" = "fpm-alpine" ]; then
+            cat <<EOF > docker-compose.yml
+            services:
+              drupal:
+                image: drupal-test:${{ matrix.php_version }}-${{ matrix.variant }}
+                container_name: drupal
+                volumes:
+                  - ./drupal-root:/var/www/html
+              nginx:
+                image: nginx:alpine
+                container_name: nginx
+                ports:
+                  - "8080:80"
+                volumes:
+                  - ./drupal-root:/var/www/html
+                  - ./tests/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+                depends_on:
+                  - drupal
+          EOF
+          elif [ "${{ matrix.variant }}" = "frankenphp-trixie" ]; then
+            cat <<EOF > docker-compose.yml
+            services:
+              drupal:
+                image: drupal-test:${{ matrix.php_version }}-${{ matrix.variant }}
+                container_name: drupal
+                volumes:
+                  - ./drupal-root:/app
+                ports:
+                  - "8080:80"
+          EOF
+          else
+            cat <<EOF > docker-compose.yml
+            services:
+              drupal:
+                image: drupal-test:${{ matrix.php_version }}-${{ matrix.variant }}
+                container_name: drupal
+                volumes:
+                  - ./drupal-root:/var/www/html
+                ports:
+                  - "8080:80"
+          EOF
+          fi
+          docker compose up -d
           sleep 10
-          docker exec ${{ env.CONTAINER_NAME }} sh -c "apt-get update && apt-get install -y --no-install-recommends git curl unzip rsync"
+          docker compose ps
 
       - name: Install Drupal
         run: |
-          docker exec --workdir ${{ env.WEB_ROOT }} ${{ env.CONTAINER_NAME }} sh -c "composer create-project drupal/recommended-project drupal_project --no-interaction && rsync -a drupal_project/ . && rm -rf drupal_project"
-          docker exec --workdir ${{ env.WEB_ROOT }} ${{ env.CONTAINER_NAME }} sh -c "composer require drush/drush"
+          chmod +x tests/install-drupal.sh
+          # The script uses 'docker compose exec -T drupal', which matches our service name 'drupal'
+          ./tests/install-drupal.sh ${{ matrix.variant }} "11.x"
 
-      - name: Enable PHP error display for debugging
+      - name: Run Drupal verification tests
         run: |
-          PHP_INI_PATH=$(docker exec ${{ env.CONTAINER_NAME }} php -i | grep "Loaded Configuration File" | cut -d' ' -f5)
-          docker exec ${{ env.CONTAINER_NAME }} sh -c "sed -i 's/display_errors = Off/display_errors = On/g' $PHP_INI_PATH"
-          docker exec ${{ env.CONTAINER_NAME }} sh -c "sed -i 's/error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT/error_reporting = E_ALL/g' $PHP_INI_PATH"
+          chmod +x tests/verify-drupal.sh
+          ./tests/verify-drupal.sh ${{ matrix.variant }}
 
-      - name: Configure Apache
-        if: matrix.variant == 'apache-trixie'
-        run: |
-          docker exec ${{ env.CONTAINER_NAME }} a2enmod rewrite
-          docker exec ${{ env.CONTAINER_NAME }} apache2ctl -k graceful
-
-      - name: Install Drupal site
-        run: |
-          docker exec ${{ env.CONTAINER_NAME }} sh -c "mkdir -p ${{ env.WEB_ROOT }}/web/sites/default/files && chmod -R 777 ${{ env.WEB_ROOT }}/web/sites/default/files"
-          docker exec ${{ env.CONTAINER_NAME }} sh -c "chmod 777 ${{ env.WEB_ROOT }}/web/sites/default"
-          
-          docker exec --workdir ${{ env.WEB_ROOT }}/web ${{ env.CONTAINER_NAME }} sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
-          
-          docker exec ${{ env.CONTAINER_NAME }} sh -c "chmod 755 ${{ env.WEB_ROOT }}/web/sites/default"
-          docker exec ${{ env.CONTAINER_NAME }} sh -c "chmod -R 777 ${{ env.WEB_ROOT }}/web/sites/default/files"
-
-          sleep 10
-
-      - name: Verify Drupal installation
-        run: curl -v --fail http://localhost:${{ env.PORT }}
-
-      - name: Show logs on failure
+      - name: Capture logs on failure
         if: failure()
         run: |
-          echo "::group::File permissions on sites/default"
-          docker exec ${{ env.CONTAINER_NAME }} ls -la ${{ env.WEB_ROOT }}/web/sites/default
-          echo "::endgroup::"
-          echo "::group::Docker logs"
-          docker logs ${{ env.CONTAINER_NAME }}
-          echo "::endgroup::"
-          if [ "${{ matrix.variant }}" = "apache-trixie" ]; then
-            echo "::group::Apache error log"
-            timeout 10s docker exec ${{ env.CONTAINER_NAME }} tail -n 100 /var/log/apache2/error.log
-            echo "::endgroup::"
-          fi
+          echo "=== Docker Compose Logs ==="
+          docker compose logs
+          echo "=== Container Status ==="
+          docker compose ps
+          docker compose logs > test-results/docker-logs-${{ matrix.variant }}.txt
 
-  test-fpm:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php_version: ["8.4", "8.5"]
-        variant: ["fpm-alpine"]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Compose
-        uses: docker/setup-compose-action@v1
-
-      - name: Create docker-compose for testing
-        run: |
-          cat <<EOF > docker-compose.test.yml
-          services:
-            php-fpm:
-              build:
-                context: ./php8/fpm-alpine
-                args:
-                  PHP_VERSION: ${{ matrix.php_version }}
-              container_name: php-fpm
-              volumes:
-                - drupal-code:/var/www/html
-            nginx:
-              image: nginx:alpine
-              container_name: nginx
-              ports:
-                - "8080:80"
-              volumes:
-                - drupal-code:/var/www/html
-                - ./nginx.conf:/etc/nginx/conf.d/default.conf
-          volumes:
-            drupal-code:
-          EOF
-
-      - name: Create nginx config
-        run: |
-          cat <<EOF > nginx.conf
-          server {
-              listen 80;
-              server_name localhost;
-              root /var/www/html/web;
-              index index.php;
-
-              location / {
-                  try_files \$uri /index.php?\$query_string;
-              }
-
-              location ~ \.php$ {
-                  fastcgi_pass php-fpm:9000;
-                  fastcgi_index index.php;
-                  include fastcgi_params;
-                  fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
-              }
-          }
-          EOF
-
-      - name: Start services
-        run: docker compose -f docker-compose.test.yml up -d --build
-
-      - name: Install Drupal
-        run: |
-          sleep 10
-          docker exec php-fpm sh -c "apk add --no-cache git curl unzip"
-          docker exec --workdir /var/www/html php-fpm sh -c "composer create-project drupal/recommended-project . --no-interaction"
-          docker exec --workdir /var/www/html php-fpm sh -c "composer require drush/drush"
-
-      - name: Enable PHP error display for debugging
-        run: |
-          PHP_INI_PATH=$(docker exec php-fpm php -i | grep "Loaded Configuration File" | cut -d' ' -f5)
-          docker exec php-fpm sh -c "sed -i 's/display_errors = Off/display_errors = On/g' $PHP_INI_PATH"
-          docker exec php-fpm sh -c "sed -i 's/error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT/error_reporting = E_ALL/g' $PHP_INI_PATH"
-          docker exec php-fpm kill -USR2 1
-          sleep 5
-
-      - name: Install Drupal site
-        run: |
-          docker exec php-fpm sh -c "mkdir -p /var/www/html/web/sites/default/files && chmod -R 777 /var/www/html/web/sites/default/files"
-          docker exec php-fpm sh -c "chmod 777 /var/www/html/web/sites/default"
-
-          docker exec --workdir /var/www/html/web php-fpm sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
-
-          docker exec php-fpm sh -c "chmod 755 /var/www/html/web/sites/default"
-          docker exec php-fpm sh -c "chmod -R 777 /var/www/html/web/sites/default/files"
-          sleep 10
-
-      - name: Verify Drupal installation
-        run: curl -v --fail http://localhost:8080
-
-      - name: Show logs on failure
-        if: failure()
-        run: |
-          echo "::group::File permissions on sites/default"
-          docker exec php-fpm ls -la /var/www/html/web/sites/default
-          echo "::endgroup::"
-          echo "::group::PHP-FPM container logs"
-          docker logs php-fpm
-          echo "::endgroup::"
-          echo "::group::Nginx container logs"
-          docker logs nginx
-          echo "::endgroup::"
-          echo "::group::Nginx error log"
-          timeout 10s docker exec nginx tail -n 100 /var/log/nginx/error.log
-          echo "::endgroup::"
-
-      - name: Stop services
+      - name: Upload test results
         if: always()
-        run: docker compose -f docker-compose.test.yml down --volumes
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.php_version }}-${{ matrix.variant }}
+          path: test-results/
+
+      - name: Clean up
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/test-drupal.yml
+++ b/.github/workflows/test-drupal.yml
@@ -64,8 +64,13 @@ jobs:
 
       - name: Install Drupal site
         run: |
-          docker exec ${{ env.CONTAINER_NAME }} chmod -R 777 ${{ env.WEB_ROOT }}
+          docker exec ${{ env.CONTAINER_NAME }} sh -c "mkdir -p ${{ env.WEB_ROOT }}/web/sites/default/files && chmod -R 777 ${{ env.WEB_ROOT }}/web/sites/default/files"
+          docker exec ${{ env.CONTAINER_NAME }} sh -c "chmod 777 ${{ env.WEB_ROOT }}/web/sites/default"
+          
           docker exec --workdir ${{ env.WEB_ROOT }}/web ${{ env.CONTAINER_NAME }} sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
+          
+          docker exec ${{ env.CONTAINER_NAME }} sh -c "chmod 755 ${{ env.WEB_ROOT }}/web/sites/default"
+          docker exec ${{ env.CONTAINER_NAME }} sh -c "chmod -R 777 ${{ env.WEB_ROOT }}/web/sites/default/files"
 
           sleep 10
 
@@ -166,8 +171,13 @@ jobs:
 
       - name: Install Drupal site
         run: |
-          docker exec php-fpm chmod -R 777 /var/www/html
+          docker exec php-fpm sh -c "mkdir -p /var/www/html/web/sites/default/files && chmod -R 777 /var/www/html/web/sites/default/files"
+          docker exec php-fpm sh -c "chmod 777 /var/www/html/web/sites/default"
+
           docker exec --workdir /var/www/html/web php-fpm sh -c "../vendor/bin/drush site-install standard --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='Test' -y"
+
+          docker exec php-fpm sh -c "chmod 755 /var/www/html/web/sites/default"
+          docker exec php-fpm sh -c "chmod -R 777 /var/www/html/web/sites/default/files"
           sleep 10
 
       - name: Verify Drupal installation

--- a/tests/docker-compose.fpm.yml
+++ b/tests/docker-compose.fpm.yml
@@ -1,0 +1,16 @@
+services:
+  drupal:
+    image: drupal-test:${PHP_VERSION}-${VARIANT}
+    container_name: drupal
+    volumes:
+      - ../drupal-root:/var/www/html
+  nginx:
+    image: nginx:alpine
+    container_name: nginx
+    ports:
+      - "8080:80"
+    volumes:
+      - ../drupal-root:/var/www/html
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - drupal

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  drupal:
+    image: drupal-test:${PHP_VERSION}-${VARIANT}
+    container_name: drupal
+    volumes:
+      - ../drupal-root:${WEB_ROOT}
+    ports:
+      - "8080:80"

--- a/tests/install-drupal.sh
+++ b/tests/install-drupal.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -e
+
+VARIANT=$1
+DRUPAL_VERSION=$2
+
+echo "===================================="
+echo "Installing Drupal ${DRUPAL_VERSION} on ${VARIANT}"
+echo "===================================="
+
+# Use service name instead of container name
+SERVICE="drupal"
+
+# Set the web root path based on variant
+if [[ "$VARIANT" == *"frankenphp"* ]]; then
+    WEBROOT="/app"
+else
+    WEBROOT="/var/www/html"
+fi
+
+# Wait for the container to be fully ready with health checks
+echo "Waiting for container to be ready..."
+for i in {1..12}; do
+    if docker compose exec -T $SERVICE sh -c 'exit 0' 2>/dev/null; then
+        echo "Container is ready!"
+        break
+    fi
+    if [ $i -eq 12 ]; then
+        echo "Container failed to become ready after 60 seconds"
+        docker compose ps
+        docker compose logs
+        exit 1
+    fi
+    echo "Waiting for container... ($i/12)"
+    sleep 5
+done
+
+# Check if Drupal is already installed
+INSTALLED=$(docker compose exec -T $SERVICE sh -c "if [ -f ${WEBROOT}/web/sites/default/settings.php ] && grep -q 'database' ${WEBROOT}/web/sites/default/settings.php 2>/dev/null; then echo 'yes'; else echo 'no'; fi" || echo "no")
+
+if [ "$INSTALLED" = "yes" ]; then
+    echo "Drupal appears to be already installed. Skipping installation."
+    exit 0
+fi
+
+# Set proper permissions
+echo "Setting up permissions..."
+docker compose exec -T $SERVICE sh -c "mkdir -p ${WEBROOT}/web/sites/default/files && chmod -R 777 ${WEBROOT}/web/sites/default/files"
+docker compose exec -T $SERVICE sh -c "chmod 777 ${WEBROOT}/web/sites/default"
+
+# Install Drupal using drush with SQLite database file
+echo "Installing Drupal using drush with SQLite..."
+docker compose exec -T $SERVICE sh -c "cd ${WEBROOT} && vendor/bin/drush site:install minimal \
+    --db-url="sqlite://localhost/sites/default/files/.ht.sqlite" \
+    --site-name="Drupal Test Site" \
+    --account-name=admin \
+    --account-pass=admin \
+    --yes \
+    --no-interaction"
+
+# Verify installation
+echo "Verifying Drupal installation..."
+DRUSH_STATUS=$(docker compose exec -T $SERVICE sh -c "cd ${WEBROOT} && vendor/bin/drush status --format=json" || echo "{}")
+
+echo "Drush status output:"
+echo "$DRUSH_STATUS"
+
+# Check if bootstrap was successful
+if echo "$DRUSH_STATUS" | grep -q "bootstrap"; then
+    echo "✓ Drupal installation completed successfully"
+else
+    echo "✗ Drupal installation may have issues"
+    exit 1
+fi
+
+# Set permissions back to safer values but keep files directory writable
+echo "Securing permissions..."
+# sites/default should not be writable by web server (755)
+docker compose exec -T $SERVICE sh -c "chmod 755 ${WEBROOT}/web/sites/default"
+# Keep files directory fully writable (777) for testing - SQLite needs directory write access
+docker compose exec -T $SERVICE sh -c "chmod -R 777 ${WEBROOT}/web/sites/default/files"
+
+echo "===================================="
+echo "Drupal installation complete"
+echo "Admin user: admin"
+echo "Admin pass: admin"
+echo "===================================="

--- a/tests/nginx.conf
+++ b/tests/nginx.conf
@@ -1,0 +1,129 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /var/www/html/web;
+
+    index index.php index.html index.htm;
+
+    # Logging
+    access_log /var/log/nginx/drupal_access.log;
+    error_log /var/log/nginx/drupal_error.log;
+
+    # Drupal specific configurations
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    # Very rarely should these ever be accessed outside of your lan
+    location ~* \.(txt|log)$ {
+        deny all;
+    }
+
+    location ~ \..*/.*\.php$ {
+        return 403;
+    }
+
+    location ~ ^/sites/.*/private/ {
+        return 403;
+    }
+
+    # Block access to scripts in site files directory
+    location ~ ^/sites/[^/]+/files/.*\.php$ {
+        deny all;
+    }
+
+    # Allow "Well-Known URIs" as per RFC 5785
+    location ~* ^/.well-known/ {
+        allow all;
+    }
+
+    # Block access to "hidden" files and directories whose names begin with a
+    # period. This includes directories used by version control systems such
+    # as Subversion or Git to store control files.
+    location ~ (^|/)\. {
+        return 403;
+    }
+
+    location / {
+        # try_files $uri @rewrite; # For Drupal <= 6
+        try_files $uri /index.php?$query_string; # For Drupal >= 7
+    }
+
+    location @rewrite {
+        rewrite ^/(.*)$ /index.php?q=$1;
+    }
+
+    # Don't allow direct access to PHP files in the vendor directory.
+    location ~ /vendor/.*\.php$ {
+        deny all;
+        return 404;
+    }
+
+    # Protect files and directories from prying eyes.
+    location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock)|web\.config)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
+        deny all;
+        return 404;
+    }
+
+    location ~ '\.php$|^/update.php' {
+        fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
+        
+        # Ensure the php file exists. Mitigates CVE-2019-11043
+        try_files $fastcgi_script_name =404;
+        
+        # Block httpoxy attacks. See https://httpoxy.org/.
+        fastcgi_param HTTP_PROXY "";
+        
+        fastcgi_pass drupal:9000;
+        fastcgi_index index.php;
+        
+        include fastcgi_params;
+        
+        # SCRIPT_FILENAME parameter is used for PHP FPM determining
+        # the script name. If it is not set in fastcgi_params file,
+        # i.e. /etc/nginx/fastcgi_params or in the parent contexts,
+        # please comment off following line:
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_param QUERY_STRING $query_string;
+        
+        fastcgi_intercept_errors on;
+        
+        # PHP 7 socket
+        # fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+        
+        # PHP 7 TCP
+        # fastcgi_pass 127.0.0.1:9000;
+        
+        fastcgi_buffer_size 128k;
+        fastcgi_buffers 4 256k;
+        fastcgi_busy_buffers_size 256k;
+        fastcgi_temp_file_write_size 256k;
+        fastcgi_read_timeout 240;
+    }
+
+    # Fighting with Styles? This little gem is amazing.
+    location ~ ^/sites/.*/files/styles/ {
+        try_files $uri @rewrite;
+    }
+
+    # Handle private files through Drupal. Private file's path can come
+    # with a language prefix.
+    location ~ ^(/[a-z\-]+)?/system/files/ {
+        try_files $uri /index.php?$query_string;
+    }
+
+    # Enforce clean URLs
+    # Removes index.php from urls like www.example.com/index.php/my-page --> www.example.com/my-page
+    # Could be done with 301 for permanent or other redirect codes.
+    if ($request_uri ~* "^(.*/)index\.php/(.*)") {
+        return 307 $1$2;
+    }
+}

--- a/tests/verify-drupal.sh
+++ b/tests/verify-drupal.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+# Don't use set -e so we can run debugging on test failures
+set +e
+
+VARIANT=$1
+
+echo "===================================="
+echo "Verifying Drupal installation on ${VARIANT}"
+echo "===================================="
+
+# Determine the base URL and use service name
+BASE_URL="http://localhost:8080"
+SERVICE="drupal"
+
+# Set the web root path based on variant
+if [[ "$VARIANT" == *"frankenphp"* ]]; then
+    WEBROOT="/app"
+else
+    WEBROOT="/var/www/html"
+fi
+
+# Wait a bit for services to stabilize
+sleep 3
+
+# Function to test HTTP endpoint
+test_endpoint() {
+    local url=$1
+    local description=$2
+    local expected_code=${3:-200}
+    
+    echo -n "Testing $description... "
+    
+    # Use curl to test the endpoint
+    response=$(curl -s -o /dev/null -w "%{http_code}" -L "$url" 2>&1 || echo "000")
+    
+    if [ "$response" = "$expected_code" ]; then
+        echo "✓ PASSED (HTTP $response)"
+        return 0
+    else
+        echo "✗ FAILED (Expected HTTP $expected_code, got HTTP $response)"
+        return 1
+    fi
+}
+
+# Function to test page content
+test_content() {
+    local url=$1
+    local description=$2
+    local search_term=$3
+    
+    echo -n "Testing $description for '$search_term'... "
+    
+    # Use curl to fetch the page content
+    content=$(curl -s -L "$url" 2>&1 || echo "")
+    
+    if echo "$content" | grep -q "$search_term"; then
+        echo "✓ PASSED"
+        return 0
+    else
+        echo "✗ FAILED (Content not found)"
+        echo "Page content preview:"
+        echo "$content" | head -20
+        return 1
+    fi
+}
+
+# Track test results
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+echo ""
+echo "Running HTTP endpoint tests..."
+echo "--------------------------------"
+
+# Test 1: Homepage returns 200
+if test_endpoint "$BASE_URL" "Homepage"; then
+    ((TESTS_PASSED++))
+else
+    ((TESTS_FAILED++))
+    echo ""
+    echo "=== DEBUGGING HTTP 500 ERROR ==="
+    echo "--- Fetching page content with error details ---"
+    curl -v "$BASE_URL" 2>&1 | head -50
+    echo ""
+    echo "--- Checking file permissions ---"
+    docker compose exec -T $SERVICE sh -c "ls -la ${WEBROOT}/web/sites/default/files/" || true
+    echo ""
+    echo "--- Checking web server user ---"
+    docker compose exec -T $SERVICE sh -c 'ps aux | grep -E "(apache|httpd|nginx|php-fpm|frankenphp)" | grep -v grep | head -5' || true
+    echo ""
+    echo "--- Checking if web server user can write to files directory ---"
+    docker compose exec -T $SERVICE sh -c "su -s /bin/sh www-data -c 'touch ${WEBROOT}/web/sites/default/files/test-write.txt && rm ${WEBROOT}/web/sites/default/files/test-write.txt && echo Write_test:_SUCCESS' 2>&1 || su -s /bin/sh apache -c 'touch ${WEBROOT}/web/sites/default/files/test-write.txt && rm ${WEBROOT}/web/sites/default/files/test-write.txt && echo Write_test:_SUCCESS' 2>&1 || echo Write_test:_FAILED" || true
+    echo ""
+    echo "--- Checking PHP error log (last 50 lines) ---"
+    docker compose exec -T $SERVICE sh -c 'tail -50 /var/log/apache2/error.log 2>/dev/null || tail -50 /var/log/php-fpm/error.log 2>/dev/null || tail -50 /var/log/php8/error.log 2>/dev/null || echo "Could not find PHP error log"' || true
+    echo ""
+    echo "--- Checking Apache/Nginx error log (last 50 lines) ---"
+    docker compose exec -T $SERVICE sh -c 'tail -50 /var/log/apache2/error.log 2>/dev/null || tail -50 /var/log/nginx/error.log 2>/dev/null || echo "Could not find web server error log"' || true
+    echo ""
+    echo "--- Checking Drupal logs directory ---"
+    docker compose exec -T $SERVICE sh -c "ls -la ${WEBROOT}/web/sites/default/files/ 2>/dev/null | head -20" || true
+    echo ""
+    echo "--- Checking Drupal watchdog errors ---"
+    docker compose exec -T $SERVICE sh -c "cd ${WEBROOT} && vendor/bin/drush watchdog:show --severity=Error --count=10 2>&1" || true
+    echo ""
+    echo "--- Checking SQLite database permissions ---"
+    docker compose exec -T $SERVICE sh -c "ls -la ${WEBROOT}/web/sites/default/files/.ht.sqlite* 2>/dev/null" || true
+    echo ""
+    echo "--- Checking PHP modules loaded via web server ---"
+    docker compose exec -T $SERVICE sh -c "echo '<?php header(\"Content-Type: text/plain\"); foreach (get_loaded_extensions() as \$ext) { echo \$ext . \"\\n\"; }' > ${WEBROOT}/web/check_modules.php" || true
+    echo "Modules from web server:"
+    curl -s "$BASE_URL/check_modules.php" 2>&1 | head -50
+    echo ""
+    echo "--- Checking PHP modules via CLI (for comparison) ---"
+    docker compose exec -T $SERVICE sh -c 'php -m | grep -iE "(pdo|sqlite|opcache)"' || true
+    echo "=== END DEBUGGING ==="
+    echo ""
+fi
+
+# Test 2: User login page returns 200
+if test_endpoint "$BASE_URL/user/login" "Login page"; then
+    ((TESTS_PASSED++))
+else
+    ((TESTS_FAILED++))
+fi
+
+# Test 3: Admin page (should redirect to login with 200, or return 403 for unauthorized)
+echo -n "Testing Admin page... "
+ADMIN_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -L "$BASE_URL/admin" 2>&1 || echo "000")
+if [ "$ADMIN_RESPONSE" = "200" ] || [ "$ADMIN_RESPONSE" = "403" ]; then
+    echo "✓ PASSED (HTTP $ADMIN_RESPONSE)"
+    ((TESTS_PASSED++))
+else
+    echo "✗ FAILED (Expected HTTP 200 or 403, got HTTP $ADMIN_RESPONSE)"
+    ((TESTS_FAILED++))
+fi
+
+# Test 4: Check for Drupal meta tag on homepage
+if test_content "$BASE_URL" "Homepage content" "Drupal"; then
+    ((TESTS_PASSED++))
+else
+    ((TESTS_FAILED++))
+fi
+
+# Test 5: Check status page via drush
+echo -n "Testing Drupal status via drush... "
+DRUSH_CHECK=$(docker compose exec -T $SERVICE sh -c "cd ${WEBROOT} && vendor/bin/drush status --fields=bootstrap 2>&1" || echo "")
+
+if echo "$DRUSH_CHECK" | grep -q "Successful"; then
+    echo "✓ PASSED"
+    ((TESTS_PASSED++))
+else
+    echo "✗ FAILED"
+    echo "Drush output: $DRUSH_CHECK"
+    ((TESTS_FAILED++))
+fi
+
+# Test 6: Check PHP version in container
+echo -n "Testing PHP availability... "
+PHP_VERSION=$(docker compose exec -T $SERVICE php -v 2>&1 || echo "")
+
+if echo "$PHP_VERSION" | grep -q "PHP"; then
+    echo "✓ PASSED"
+    echo "   PHP Version: $(echo "$PHP_VERSION" | head -1)"
+    ((TESTS_PASSED++))
+else
+    echo "✗ FAILED"
+    ((TESTS_FAILED++))
+fi
+
+# Test 7: Check required PHP extensions
+echo -n "Testing required PHP extensions... "
+REQUIRED_EXTENSIONS="gd pdo pdo_sqlite json opcache"
+MISSING_EXTENSIONS=""
+
+for ext in $REQUIRED_EXTENSIONS; do
+    # Use case-insensitive matching and handle "Zend OPcache" naming
+    if [ "$ext" = "opcache" ]; then
+        if ! docker compose exec -T $SERVICE php -m | grep -qi "opcache"; then
+            MISSING_EXTENSIONS="$MISSING_EXTENSIONS $ext"
+        fi
+    elif ! docker compose exec -T $SERVICE php -m | grep -qi "^$ext$"; then
+        MISSING_EXTENSIONS="$MISSING_EXTENSIONS $ext"
+    fi
+done
+
+if [ -z "$MISSING_EXTENSIONS" ]; then
+    echo "✓ PASSED"
+    ((TESTS_PASSED++))
+else
+    echo "✗ FAILED (Missing:$MISSING_EXTENSIONS)"
+    ((TESTS_FAILED++))
+fi
+
+# Test 8: Check web root permissions
+echo -n "Testing web root is readable... "
+WEB_ROOT_CHECK=$(docker compose exec -T $SERVICE sh -c "test -r ${WEBROOT}/web/index.php && echo readable" || echo "")
+
+if [ "$WEB_ROOT_CHECK" = "readable" ]; then
+    echo "✓ PASSED"
+    ((TESTS_PASSED++))
+else
+    echo "✗ FAILED"
+    ((TESTS_FAILED++))
+fi
+
+# Summary
+echo ""
+echo "===================================="
+echo "Test Results Summary"
+echo "===================================="
+echo "Tests passed: $TESTS_PASSED"
+echo "Tests failed: $TESTS_FAILED"
+echo "===================================="
+
+if [ $TESTS_FAILED -eq 0 ]; then
+    echo "✓ All tests passed!"
+    exit 0
+else
+    echo "✗ Some tests failed!"
+    exit 1
+fi


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow (`test-drupal.yml`) designed to test Drupal installations. The workflow supports multiple PHP versions (8.4, 8.5) and different web server variants (Apache, FrankenPHP, FPM with Nginx).

The workflow performs the following steps for each matrix combination:
- Builds a Docker image specific to the PHP version and web server variant.
- Executes Drupal installation using Composer and Drush.
- Configures the web server (Apache rewrite module or Nginx).
- Attempts to install Drupal using the SQLite database.
- Verifies a successful installation by making an HTTP request and checking for a 200 OK status.

This ensures that Drupal can be successfully installed and run with the configured environments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automated workflow to validate Drupal installations across PHP versions (8.4, 8.5) and server setups (Apache, FrankenPHP, PHP‑FPM + nginx), including environment build, site installation, HTTP endpoint checks, and cleanup.

* **Chores**
  * Adjusted CI trigger/guard logic to coordinate with the validation workflow and refined the PHP variant matrix formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->