### PR TITLE
docs: align variants list and Caddyfile snippet with shipped images

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ This image provides a basic runtime for Drupal projects. It's designed for CI bu
 
 ## Image Variants
 
-This repository contains two main variants of the Drupal base image:
+This repository publishes four variants of the Drupal base image:
 
-- `apache-bookworm`: Based on Debian Bookworm with Apache.
-- `fpm-alpine`: Based on Alpine Linux with PHP-FPM.
-- `frankenphp-trixie`: Based on Debian Trixie with FrankenPHP (experimental).
+- `apache-trixie` (default): Based on Debian Trixie with Apache. Backs the `latest` and `php8.X` tags.
+- `apache-bookworm`: Based on Debian Bookworm with Apache. Kept for users on older hosts; not the recommended default.
+- `fpm-alpine`: Based on Alpine Linux with PHP-FPM. Pair with a separate web server like Nginx.
+- `frankenphp-trixie`: Based on Debian Trixie with FrankenPHP (Caddy + PHP in one process).
 
-Choose the image that best fits your needs. The Apache image is a good choice for a simple, all-in-one container, while the FPM image is ideal for use with a separate web server like Nginx.
+Choose the image that best fits your needs. The Apache image is a good choice for a simple, all-in-one container, the FPM image is ideal for use with a separate web server like Nginx, and FrankenPHP offers a modern single-binary alternative with built-in HTTPS support.
 
 ## Supported PHP Versions
 
@@ -212,19 +213,49 @@ services:
 
 #### Default Caddyfile
 
-The image includes a default Caddyfile optimized for Drupal:
+The image ships with a Drupal-tuned Caddyfile that blocks access to sensitive paths, denies PHP execution from upload directories, and sets long-lived cache headers on static assets:
 
 ```caddyfile
 {
-    frankenphp
-    order php_server before file_server
+	frankenphp
+	order php_server before file_server
 }
 
 :80 {
-    encode zstd gzip
-    root * /app/web
-    php_server
-    file_server
+	encode zstd br gzip
+	root * /app/web
+
+	# Block hidden PHP files
+	@hiddenPhp path_regexp \..*/.*.php$
+	error @hiddenPhp 403
+
+	# Block PHP in vendor
+	@vendorPhp path_regexp /vendor/.*\.php$
+	error @vendorPhp 404
+
+	# Block PHP in files directories
+	@filesPhp path_regexp ^/sites/[^/]+/files/.*\.php$
+	error @filesPhp 404
+
+	# Block private directories
+	@private path_regexp ^/sites/.*/private/
+	error @private 403
+
+	# Block sensitive files (allow .well-known)
+	@protected {
+		not path /.well-known*
+		path_regexp \.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^/(\..+|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock)|web\.config|yarn\.lock|package\.json)$|^\/#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$
+	}
+	error @protected 403
+
+	# Static assets caching
+	@static {
+		file
+		path *.avif *.css *.eot *.gif *.gz *.ico *.jpg *.jpeg *.js *.otf *.pdf *.png *.svg *.ttf *.webp *.woff *.woff2
+	}
+	header @static Cache-Control "public, max-age=31536000, immutable"
+
+	php_server
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This image supports the following PHP versions:
 - PHP 8.4
 - PHP 8.5 (latest)
 
-Each version is available in all variants (apache-bookworm, apache-trixie, fpm-alpine, frankenphp-trixie).
+PHP 8.2–8.5 are available in the `apache-trixie`, `apache-bookworm`, and `fpm-alpine` variants. The `frankenphp-trixie` variant is published for PHP 8.4 and 8.5 only.
 
 ### Available Tags
 

--- a/php8/frankenphp-trixie/Caddyfile
+++ b/php8/frankenphp-trixie/Caddyfile
@@ -1,7 +1,6 @@
 {
 	frankenphp
 	order php_server before file_server
-	order php before file_server
 }
 
 :80 {


### PR DESCRIPTION
## Summary

- README's Image Variants section listed three variants and omitted `apache-trixie` — which is actually the default backing the `latest` and `php8.X` tags. Fixed the list, reframed `apache-bookworm` as legacy/compat, and dropped the "experimental" wording on FrankenPHP (the variant has been going through full CI for a while).
- The "Default Caddyfile" snippet in the README didn't match the file shipped in `php8/frankenphp-trixie/Caddyfile` — the real file has security rules and static-asset caching that the doc snippet skipped. Replaced the snippet with the actual contents so users copying it get the same behavior as the image.
- Removed a dead directive in `php8/frankenphp-trixie/Caddyfile`: `order php before file_server`. FrankenPHP only registers `php_server`; this line did nothing.

## Test plan

- [ ] Render the README on GitHub and confirm the variants list and the Caddyfile snippet read correctly.
- [ ] CI build passes for the `frankenphp-trixie` matrix cells (the Caddyfile change is what's being exercised).
- [ ] Manually start a FrankenPHP container with the updated Caddyfile and confirm no startup warnings about unknown `php` directive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Image Variants section with published variant details and tagging information.
  * Enhanced FrankenPHP Caddyfile configuration with improved Drupal support, including security protections for sensitive paths and cache-control headers for static assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->