### PR TITLE
feat: add OCI labels and HEALTHCHECK to all variants

### DIFF
--- a/php8/apache-bookworm/Dockerfile
+++ b/php8/apache-bookworm/Dockerfile
@@ -2,6 +2,13 @@ ARG PHP_VERSION=8.4
 # from https://www.drupal.org/docs/system-requirements/php-requirements
 FROM php:${PHP_VERSION}-apache-bookworm
 
+ARG PHP_VERSION
+LABEL org.opencontainers.image.source="https://github.com/hussainweb/docker-drupal-base" \
+      org.opencontainers.image.url="https://hub.docker.com/r/hussainweb/drupal-base" \
+      org.opencontainers.image.title="Drupal base (apache-bookworm)" \
+      org.opencontainers.image.description="Drupal-ready PHP ${PHP_VERSION} runtime on Debian Bookworm with Apache (legacy variant)" \
+      org.opencontainers.image.version="${PHP_VERSION}"
+
 # install the PHP extensions we need
 RUN set -eux; \
 	\
@@ -149,3 +156,6 @@ WORKDIR /var/www/html
 ENV COMPOSER_ALLOW_SUPERUSER=1
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 ENV PATH=${PATH}:/var/www/html/vendor/bin
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+	CMD ["php", "-r", "exit(@fsockopen('127.0.0.1', 80, $e, $s, 2) ? 0 : 1);"]

--- a/php8/apache-trixie/Dockerfile
+++ b/php8/apache-trixie/Dockerfile
@@ -2,6 +2,13 @@ ARG PHP_VERSION=8.4
 # from https://www.drupal.org/docs/system-requirements/php-requirements
 FROM php:${PHP_VERSION}-apache-trixie
 
+ARG PHP_VERSION
+LABEL org.opencontainers.image.source="https://github.com/hussainweb/docker-drupal-base" \
+      org.opencontainers.image.url="https://hub.docker.com/r/hussainweb/drupal-base" \
+      org.opencontainers.image.title="Drupal base (apache-trixie)" \
+      org.opencontainers.image.description="Drupal-ready PHP ${PHP_VERSION} runtime on Debian Trixie with Apache" \
+      org.opencontainers.image.version="${PHP_VERSION}"
+
 # install the PHP extensions we need
 RUN set -eux; \
 	\
@@ -124,3 +131,6 @@ WORKDIR /var/www/html
 ENV COMPOSER_ALLOW_SUPERUSER=1
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 ENV PATH=${PATH}:/var/www/html/vendor/bin
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+	CMD ["php", "-r", "exit(@fsockopen('127.0.0.1', 80, $e, $s, 2) ? 0 : 1);"]

--- a/php8/fpm-alpine/Dockerfile
+++ b/php8/fpm-alpine/Dockerfile
@@ -2,6 +2,13 @@ ARG PHP_VERSION=8.4
 # from https://www.drupal.org/docs/system-requirements/php-requirements
 FROM php:${PHP_VERSION}-fpm-alpine
 
+ARG PHP_VERSION
+LABEL org.opencontainers.image.source="https://github.com/hussainweb/docker-drupal-base" \
+      org.opencontainers.image.url="https://hub.docker.com/r/hussainweb/drupal-base" \
+      org.opencontainers.image.title="Drupal base (fpm-alpine)" \
+      org.opencontainers.image.description="Drupal-ready PHP ${PHP_VERSION} FPM runtime on Alpine Linux" \
+      org.opencontainers.image.version="${PHP_VERSION}"
+
 # install the PHP extensions we need
 RUN set -eux; \
 	\
@@ -104,3 +111,6 @@ WORKDIR /var/www/html
 ENV COMPOSER_ALLOW_SUPERUSER=1
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 ENV PATH=${PATH}:/var/www/html/vendor/bin
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+	CMD ["php", "-r", "exit(@fsockopen('127.0.0.1', 9000, $e, $s, 2) ? 0 : 1);"]

--- a/php8/frankenphp-trixie/Dockerfile
+++ b/php8/frankenphp-trixie/Dockerfile
@@ -1,6 +1,13 @@
 ARG PHP_VERSION=8.4
 FROM dunglas/frankenphp:php${PHP_VERSION}-trixie
 
+ARG PHP_VERSION
+LABEL org.opencontainers.image.source="https://github.com/hussainweb/docker-drupal-base" \
+      org.opencontainers.image.url="https://hub.docker.com/r/hussainweb/drupal-base" \
+      org.opencontainers.image.title="Drupal base (frankenphp-trixie)" \
+      org.opencontainers.image.description="Drupal-ready PHP ${PHP_VERSION} runtime on Debian Trixie with FrankenPHP (Caddy + PHP)" \
+      org.opencontainers.image.version="${PHP_VERSION}"
+
 # install the PHP extensions we need
 RUN set -eux; \
 	apt-get update; \
@@ -117,3 +124,6 @@ COPY Caddyfile /etc/frankenphp/Caddyfile
 
 WORKDIR /app
 ENV PATH=${PATH}:/app/vendor/bin
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+	CMD ["php", "-r", "exit(@fsockopen('127.0.0.1', 80, $e, $s, 2) ? 0 : 1);"]


### PR DESCRIPTION
## Summary

- Adds `org.opencontainers.image.*` labels (source, url, title, description, version) to all four Dockerfiles. The `version` label is wired to the `PHP_VERSION` build arg so each tag advertises its PHP version. Docker Hub will pick up `image.source` and link back to this repo automatically.
- Adds a `HEALTHCHECK` to every variant. Apache and FrankenPHP probe TCP port 80; fpm-alpine probes the FastCGI port 9000. Implementation uses a small PHP one-liner with `fsockopen` (exec form so no shell interpolation), avoiding the need to install curl/wget as a runtime dep. A 2s internal timeout keeps the check from blocking the full 5s docker healthcheck window.

## Test plan

- [x] `docker buildx build --check` passes on all four variants (no warnings).
- [ ] CI matrix (`docker-buildx.yml`) builds and tests all variants successfully.
- [ ] After merge, `docker inspect --format '{{json .Config.Labels}}' hussainweb/drupal-base:php8.5` shows the OCI labels populated.
- [ ] After merge, `docker ps` shows `(healthy)` for a started container once the start-period elapses.