### PR TITLE
ci: scan, attest, and de-dup the publish workflow

### DIFF
--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -34,6 +34,9 @@ jobs:
             "fpm-alpine",
             "frankenphp-trixie",
           ]
+        # On pull_request and scheduled runs, skip PHP 8.2 and 8.3 to keep
+        # CI fast. They are only built on direct pushes to main and on
+        # workflow_dispatch. The 'none' fallback is a no-op exclude.
         exclude:
           - php_version: ${{ github.event_name != 'push' && '8.2' || 'none' }}
           - php_version: ${{ github.event_name != 'push' && '8.3' || 'none' }}
@@ -58,9 +61,6 @@ jobs:
           username: hussainweb
           password: ${{ secrets.DOCKERHUB_TOKEN }}
         if: github.ref == 'refs/heads/main'
-      - name: Set Dockerfile directory
-        if: ${{ matrix.php_version == '8.2' || matrix.php_version == '8.3' || matrix.php_version == '8.4' || matrix.php_version == '8.5' }}
-        run: echo "DOCKERFILE_DIR=php8" >> $GITHUB_ENV
       - name: Generate Docker tags
         id: tags
         run: |
@@ -108,8 +108,9 @@ jobs:
           tags: drupal-test:${{ matrix.php_version }}-${{ matrix.variant }}
           build-args: |
             PHP_VERSION=${{ matrix.php_version }}
+          # cache-from only: the multi-arch publish step below owns
+          # cache-to so we don't write near-identical caches twice.
           cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Create test directory structure
         run: |
@@ -160,6 +161,16 @@ jobs:
         if: always()
         run: docker compose down -v
 
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: drupal-test:${{ matrix.php_version }}-${{ matrix.variant }}
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"
+          vuln-type: os,library
+
       - name: Build and push Docker image for PHP ${{ matrix.php_version }}
         uses: docker/build-push-action@v7
         with:
@@ -169,5 +180,24 @@ jobs:
           build-args: |
             PHP_VERSION=${{ matrix.php_version }}
           platforms: linux/amd64,linux/arm64
+          provenance: mode=max
+          sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  dockerhub-readme:
+    name: Sync Docker Hub description
+    needs: buildx
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: hussainweb
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: hussainweb/drupal-base
+          short-description: "Drupal-ready PHP base images (Apache/FPM/FrankenPHP) for CI, dev, and production."
+          readme-filepath: ./README.md


### PR DESCRIPTION
## Summary

Production-grade hardening for the publish pipeline, in three pieces:

- **Trivy scan** runs between the test pass and the publish build. It scans the locally-loaded image with `severity: CRITICAL,HIGH`, `ignore-unfixed: true`, and `exit-code: 1` so the job fails only on fixable, high-severity vulnerabilities. This means a PR or a scheduled run that surfaces a newly-disclosed CVE upstream will block a push until the base image catches up.
- **Provenance + SBOM** attestations on the push step (`provenance: mode=max`, `sbom: true`). Both end up on Docker Hub as referrers, so consumers can verify what the image is and where it came from. SLSA mode=max captures full builder + materials info instead of just a stub.
- **Docker Hub README sync** as a new job that runs after the matrix on main pushes. Uses `peter-evans/dockerhub-description@v4` with the existing `DOCKERHUB_TOKEN` secret, so the README on Docker Hub no longer drifts from the one in this repo.

Smaller cleanups bundled in:

- The test build no longer writes to the GHA cache — only the multi-arch publish build does. The two writes were near-identical and racing each other.
- Removed the "Set Dockerfile directory" step, which was a guarded no-op (the condition matched every matrix value and the env was already set at workflow scope).
- Added a comment explaining the matrix `exclude` trick that drops PHP 8.2/8.3 on non-push events.

## Test plan

- [ ] Open this PR and confirm the matrix runs the new "Scan image for vulnerabilities" step on each cell, and that scan failures (if any) gate the publish step.
- [ ] After merge to main, confirm the `dockerhub-readme` job runs and the Docker Hub description matches `README.md`.
- [ ] After merge to main, inspect a published tag with `docker buildx imagetools inspect hussainweb/drupal-base:php8.5` and confirm `attestation-manifest` referrers exist for provenance and SBOM.
- [ ] Confirm GHA cache size doesn't grow faster than before (only one writer now).