### PR TITLE
ci: paths-ignore, swap Trivy for Grype, refresh OS packages at build

### DIFF
--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -6,13 +6,17 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "php8/**"
-      - "tests/**"
+    paths-ignore:
+      - "**/*.md"
+      - ".github/dependabot.yml"
+      - "build.sh"
+      - "clean.sh"
   pull_request:
-    paths:
-      - "php8/**"
-      - "tests/**"
+    paths-ignore:
+      - "**/*.md"
+      - ".github/dependabot.yml"
+      - "build.sh"
+      - "clean.sh"
 
 env:
   DOCKERFILE_DIR: php8

--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -166,14 +166,18 @@ jobs:
         run: docker compose down -v
 
       - name: Scan image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+        # anchore/scan-action v7.4.0, pinned by commit SHA. SHA pinning
+        # is mandatory here: the aquasecurity/trivy-action tags were
+        # hijacked in a March 2026 supply chain attack (75 of 76 tags
+        # force-pushed to an infostealer), so we standardised on
+        # SHA-pinned actions for any third-party security tooling.
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
-          image-ref: drupal-test:${{ matrix.php_version }}-${{ matrix.variant }}
-          format: table
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: "1"
-          vuln-type: os,library
+          image: drupal-test:${{ matrix.php_version }}-${{ matrix.variant }}
+          severity-cutoff: high
+          only-fixed: true
+          fail-build: true
+          output-format: table
 
       - name: Build and push Docker image for PHP ${{ matrix.php_version }}
         uses: docker/build-push-action@v7

--- a/php8/apache-bookworm/Dockerfile
+++ b/php8/apache-bookworm/Dockerfile
@@ -18,6 +18,9 @@ RUN set -eux; \
 	fi; \
 	\
 	apt-get update; \
+# pull in any security updates from Debian that the upstream base
+# image hasn't picked up yet
+	apt-get -y upgrade; \
 	apt-get install -y --no-install-recommends \
 		git \
 		unzip \

--- a/php8/apache-trixie/Dockerfile
+++ b/php8/apache-trixie/Dockerfile
@@ -18,6 +18,9 @@ RUN set -eux; \
 	fi; \
 	\
 	apt-get update; \
+# pull in any security updates from Debian that the upstream base
+# image hasn't picked up yet
+	apt-get -y upgrade; \
 	apt-get install -y --no-install-recommends \
 		git \
 		unzip \

--- a/php8/fpm-alpine/Dockerfile
+++ b/php8/fpm-alpine/Dockerfile
@@ -12,6 +12,10 @@ LABEL org.opencontainers.image.source="https://github.com/hussainweb/docker-drup
 # install the PHP extensions we need
 RUN set -eux; \
 	\
+# pull in any security updates from Alpine that the upstream base image
+# hasn't picked up yet (e.g. curl/libcurl HIGH CVEs flagged by Grype)
+	apk upgrade --no-cache; \
+	\
 	apk add --no-cache \
 		git \
 		patch \

--- a/php8/frankenphp-trixie/Dockerfile
+++ b/php8/frankenphp-trixie/Dockerfile
@@ -11,6 +11,9 @@ LABEL org.opencontainers.image.source="https://github.com/hussainweb/docker-drup
 # install the PHP extensions we need
 RUN set -eux; \
 	apt-get update; \
+# pull in any security updates from Debian that the upstream base
+# image hasn't picked up yet
+	apt-get -y upgrade; \
 	apt-get install -y --no-install-recommends \
 		git \
 		unzip \


### PR DESCRIPTION
## Summary

Three coupled changes after Trivy's tag-deletion broke the publish pipeline. In order of how I uncovered them:

### 1. paths-ignore for the trigger filter

The `paths:` filter (`"php8/**"`, `"tests/**"`) wasn't doing what it looked like it should. Concrete symptom: every PR I opened today (#29 #30 #31) modified files under `php8/**` and none triggered the workflow. The merge commits to `main` also didn't fire. Workflow run history confirms zero push/pull_request runs since the filter was added in `ebce314` — only `schedule` and `workflow_dispatch` since March 2nd.

Flip to `paths-ignore`. Run on every push to `main` and every PR, except when the entire diff is one of `**/*.md`, `.github/dependabot.yml`, `build.sh`, `clean.sh`.

### 2. Swap Trivy → Anchore Grype, pinned by commit SHA

Once CI started firing, every job failed at setup with `Unable to resolve action aquasecurity/trivy-action@0.28.0` — Aqua deleted the affected tags during cleanup after the March 2026 supply chain attack (75 of 76 trivy-action tags were force-pushed to an infostealer that exfiltrated CI secrets). PR #31 silently broke `main` and we couldn't see it until CI actually started running.

Swap to Anchore Grype (`anchore/scan-action`):

- We only use the CVE-scan piece, which is Grype's entire scope.
- Pinned by full commit SHA (`e1165082...` = v7.4.0) — sidesteps the tag-force-push attack class.
- Severity mapping preserved: `severity-cutoff: high` catches HIGH+CRITICAL, `only-fixed: true` matches the previous `ignore-unfixed` posture.

### 3. Refresh OS packages at build to absorb upstream-base lag

Grype caught a real HIGH on `php:8.5-fpm-alpine`: CVE-2026-3805 in curl/libcurl. Upstream Alpine has the fix (`curl 8.19.0-r0`), but the official `php:8.5-fpm-alpine` base is still shipping `8.17.0-r1`. The same class of issue will recur whenever the Docker library base images trail their distro's security updates.

Refresh packages at our build time, right after the base `FROM`, before we add our own runtime deps:

- `fpm-alpine`: `apk upgrade --no-cache` at the top of the install RUN.
- `apache-trixie`, `apache-bookworm`, `frankenphp-trixie`: `apt-get -y upgrade` right after the first `apt-get update`, before installing runtime tools so the `savedAptMark` capture sees the upgraded set.

Every published tag now ships current with whatever Alpine/Debian have released, regardless of when the upstream base last rebuilt.

Kept `fail-fast` on the matrix as-is — confirmed with the user that one failing cell is enough signal because the patterns repeat across variants.

## Test plan

- [x] `docker buildx build --check` passes on all four Dockerfiles after the package-refresh insert.
- [ ] CI matrix runs the Grype scan and exits clean on all eight PR-event cells (8.4/8.5 × 4 variants).
- [ ] After merge, push a doc-only commit and confirm no CI run.
- [ ] After merge, the published `php8.5-fpm-alpine` image has curl ≥ 8.19.0-r0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refined Docker build trigger conditions in CI/CD workflow to exclude non-essential file changes.
  * Replaced container vulnerability scanning tool with Anchore action.
  * Applied security package updates to all PHP container image variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->