### PR TITLE
ci: skip scheduled rebuild when registry was recently pushed

### DIFF
--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -34,8 +34,52 @@ permissions:
   contents: read
 
 jobs:
+  check-activity:
+    name: Check recent registry push
+    # Only runs on schedule; on push / workflow_dispatch / pull_request
+    # this job is skipped and `build` proceeds unconditionally.
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Compare Docker Hub last_updated against threshold
+        id: check
+        env:
+          THRESHOLD_DAYS: "10"
+        run: |
+          # Scheduled runs fire on the 1st and 15th. A push to main that
+          # lands within ~5-6 days of either date would have already
+          # rebuilt the whole matrix with fresh OS packages, so the
+          # scheduled refresh has nothing meaningful to pick up. 10 days
+          # is a middle-ground threshold: it suppresses the "push on the
+          # 25th -> rebuild on the 1st" case (6 days) while still letting
+          # the 15th refresh proceed after a push on the 2nd (13 days).
+          # Any failure to fetch the timestamp defaults to running the
+          # build -- we prefer a wasted run over a silently missed one.
+          last=$(curl -sf --max-time 30 \
+            "https://hub.docker.com/v2/repositories/${IMAGE_NAME}/" \
+            | jq -r .last_updated)
+          if [ -z "$last" ] || [ "$last" = "null" ]; then
+            echo "Could not fetch last_updated from Docker Hub; running the build."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          days=$(( ( $(date -u +%s) - $(date -u -d "$last" +%s) ) / 86400 ))
+          echo "Last registry push: $last (${days} days ago, threshold ${THRESHOLD_DAYS})"
+          if [ "$days" -ge "$THRESHOLD_DAYS" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Skipping scheduled rebuild: registry was updated ${days} days ago."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     name: Build ${{ matrix.php_version }} ${{ matrix.variant }} (${{ matrix.arch.name }})
+    needs: [check-activity]
+    # `!cancelled()` lets this job run even when `check-activity` was
+    # skipped (non-schedule events). On schedule, defer to its output.
+    if: ${{ !cancelled() && (needs.check-activity.result == 'skipped' || needs.check-activity.outputs.should_run == 'true') }}
     runs-on: ${{ matrix.arch.runs_on }}
     strategy:
       fail-fast: false

--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -64,9 +64,12 @@ jobs:
           # the 15th refresh proceed after a push on the 2nd (13 days).
           # Any failure to fetch the timestamp defaults to running the
           # build -- we prefer a wasted run over a silently missed one.
-          last=$(curl -sf --max-time 30 \
-            "https://hub.docker.com/v2/repositories/${IMAGE_NAME}/" \
-            | jq -r .last_updated)
+          # curl and jq run separately so a network failure or malformed
+          # response can't trip the runner's default `set -eo pipefail`
+          # and abort the step before this fallback runs.
+          resp=$(curl -sf --max-time 30 \
+            "https://hub.docker.com/v2/repositories/${IMAGE_NAME}/") || resp=""
+          last=$(jq -r '.last_updated // empty' <<<"$resp" 2>/dev/null) || last=""
           if [ -z "$last" ] || [ "$last" = "null" ]; then
             echo "Could not fetch last_updated from Docker Hub; running the build."
             echo "should_run=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -36,9 +36,9 @@ permissions:
 jobs:
   check-activity:
     name: Check recent registry push
-    # Only runs on schedule; on push / workflow_dispatch / pull_request
-    # this job is skipped and `build` proceeds unconditionally.
-    if: github.event_name == 'schedule'
+    # Always runs so downstream jobs can reference its output without
+    # needing `!cancelled()` / skipped-result gymnastics. On non-schedule
+    # events the step short-circuits to should_run=true immediately.
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
@@ -46,8 +46,15 @@ jobs:
       - name: Compare Docker Hub last_updated against threshold
         id: check
         env:
+          EVENT_NAME: ${{ github.event_name }}
           THRESHOLD_DAYS: "10"
         run: |
+          # Only schedule runs gate on registry activity; every other
+          # trigger proceeds unconditionally.
+          if [ "$EVENT_NAME" != "schedule" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # Scheduled runs fire on the 1st and 15th. A push to main that
           # lands within ~5-6 days of either date would have already
           # rebuilt the whole matrix with fresh OS packages, so the
@@ -77,9 +84,7 @@ jobs:
   build:
     name: Build ${{ matrix.php_version }} ${{ matrix.variant }} (${{ matrix.arch.name }})
     needs: [check-activity]
-    # `!cancelled()` lets this job run even when `check-activity` was
-    # skipped (non-schedule events). On schedule, defer to its output.
-    if: ${{ !cancelled() && (needs.check-activity.result == 'skipped' || needs.check-activity.outputs.should_run == 'true') }}
+    if: needs.check-activity.outputs.should_run == 'true'
     runs-on: ${{ matrix.arch.runs_on }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- Adds a `check-activity` preflight job that runs only on `schedule` events. It queries Docker Hub for `hussainweb/drupal-base`'s `last_updated` timestamp and outputs `should_run=false` when the registry was pushed within the last 10 days.
- Gates the existing `build` matrix on that output so cron runs become no-ops when a recent push to `main` has already refreshed the full matrix with current OS packages.
- Fail-safe: any curl/jq failure outputs `should_run=true`, so a Docker Hub blip never silently swallows the monthly OS-package refresh.

The 10-day threshold suppresses the worst case (push on the 25th → cron on the 1st, ~6 days apart) while still letting the mid-month refresh proceed after a push early in the month.

Closes #34

## Test plan

- [ ] `workflow_dispatch` on this branch — `check-activity` is skipped, `build` runs the full matrix.
- [ ] Open a PR from a no-op branch — same as above; `dockerhub-readme` stays gated by `github.event_name == 'push'`.
- [ ] On the next scheduled run after this lands, confirm `check-activity` either logs `should_run=true` with `days >= 10` and proceeds, or logs `should_run=false` and the matrix shows as skipped.
- [ ] Confirm a Docker Hub outage path: temporarily point the URL at a 404 in a throwaway branch to verify the fail-safe falls through to `should_run=true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow to conditionally trigger builds based on Docker image update intervals, reducing unnecessary build executions on scheduled runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->